### PR TITLE
Add an optional header concept and corresponding unit test.

### DIFF
--- a/LeapSerial/optional.h
+++ b/LeapSerial/optional.h
@@ -1,0 +1,139 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include <memory>
+#include <stdexcept>
+
+/// <summary>
+/// Implements the "optional" concept
+/// </summary>
+/// <remarks>
+/// TODO:  Replace this with a typedef to std::optional once the STL provides it
+/// </remarks>
+namespace leap {
+template<typename T>
+struct optional {
+public:
+  optional(void) = default;
+  optional(const optional& rhs) = default;
+  optional(optional&& rhs) :
+    m_valid(rhs.m_valid)
+  {
+    if (rhs) {
+      new(val) T{ std::move(rhs._value()) };
+      rhs._value().~T();
+      rhs.m_valid = false;
+    }
+  }
+  optional(T&& value):
+    m_valid(true)
+  {
+    new(val) T{ std::move(value) };
+  }
+
+  ~optional(void) {
+    if (m_valid)
+      reinterpret_cast<T*>(val)->~T();
+  }
+
+private:
+  bool m_valid = false;
+  uint8_t val[sizeof(T)];
+
+  T& _value(void) { return *reinterpret_cast<T*>(val); }
+  const T& _value(void) const { return *reinterpret_cast<const T*>(val); }
+
+public:
+  operator bool(void) const { return m_valid; }
+  T& value(void) {
+    if (!m_valid)
+      throw std::runtime_error("Attempted to access an uninitialized optional value");
+    return *reinterpret_cast<T*>(val);
+  }
+  const T& value(void) const { return const_cast<optional>(this)->value(); }
+
+  // Indirection operators:
+  T* operator->(void) { return &value(); }
+  const T* operator->(void) const { return &value(); }
+  T& operator*(void) { return value(); }
+  const T& operator*(void) const { return value(); }
+
+  // Comparisons
+  bool operator==(const optional& rhs) const {
+    return
+      !m_valid && !rhs.m_valid ||
+      m_valid && rhs.m_valid && _value() == rhs._value();
+  }
+  bool operator==(const T& rhs) const { return m_valid && _value() == rhs; }
+  bool operator!=(const optional& rhs) const { return !(*this == rhs); }
+  bool operator!=(const T& rhs) const { return !(*this == rhs); }
+
+  bool operator<(const optional& rhs) {
+    return
+      !m_valid && !rhs.m_valid ||
+      m_valid && rhs.m_valid && _value() < rhs._value();
+  }
+  bool operator<(const T& rhs) { return m_valid && _value() < rhs; }
+
+  // Standard assignment
+  optional& operator=(const optional& rhs) {
+    if (rhs.m_valid)
+      *this = rhs._value();
+    else if(m_valid) {
+      m_valid = false;
+      _value().~T();
+    }
+    return *this;
+  }
+
+  optional& operator=(const T& rhs) {
+    if (m_valid)
+      _value() = rhs;
+    else
+      new(val) T{ rhs };
+    m_valid = true;
+    return *this;
+  }
+  optional& operator=(T&& rhs) {
+    if (m_valid)
+      _value() = std::move(rhs);
+    else
+      new(val) T{ std::move(rhs) };
+    m_valid = true;
+    return *this;
+  }
+
+  void swap(optional& rhs) {
+    if (m_valid)
+      if (rhs.m_valid)
+        std::swap(_value(), rhs._value());
+      else {
+        new(rhs.val) T{ std::move(_value()) };
+        rhs.m_valid = true;
+        m_valid = false;
+        _value().~T();
+      }
+    else if (rhs.m_valid) {
+      new(val) T{ std::move(rhs._value()) };
+      m_valid = true;
+      rhs.m_valid = false;
+      rhs._value().~T();
+    }
+  }
+
+  template<typename... Args>
+  void emplace(Args&&... args) {
+    if (m_valid)
+      _value().~T();
+    else
+      m_valid = true;
+    new(val) T{ args... };
+  }
+};
+}
+
+namespace std {
+  template<typename T>
+  void swap(::leap::optional<T>& lhs, ::leap::optional<T>& rhs) {
+    lhs.swap(rhs);
+  }
+}

--- a/LeapSerial/optional.h
+++ b/LeapSerial/optional.h
@@ -60,8 +60,8 @@ public:
   // Comparisons
   bool operator==(const optional& rhs) const {
     return
-      !m_valid && !rhs.m_valid ||
-      m_valid && rhs.m_valid && _value() == rhs._value();
+      (!m_valid && !rhs.m_valid) ||
+      (m_valid && rhs.m_valid && _value() == rhs._value());
   }
   bool operator==(const T& rhs) const { return m_valid && _value() == rhs; }
   bool operator!=(const optional& rhs) const { return !(*this == rhs); }
@@ -69,8 +69,8 @@ public:
 
   bool operator<(const optional& rhs) {
     return
-      !m_valid && !rhs.m_valid ||
-      m_valid && rhs.m_valid && _value() < rhs._value();
+      (!m_valid && !rhs.m_valid) ||
+      (m_valid && rhs.m_valid && _value() < rhs._value());
   }
   bool operator<(const T& rhs) { return m_valid && _value() < rhs; }
 

--- a/src/leapserial/CMakeLists.txt
+++ b/src/leapserial/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LeapSerial_SRCS
   IArchiveImpl.cpp
   OArchiveImpl.h
   OArchiveImpl.cpp
+  optional.h
   LeapSerial.h
   serial_traits.h
   Utility.hpp

--- a/src/leapserial/test/CMakeLists.txt
+++ b/src/leapserial/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LeapSerialTest_SRCS
   ArchiveJSONTest.cpp
   LeapArchiveTest.cpp
+  OptionalTest.cpp
   PrettyPrintTest.cpp
   SerialFormatTest.cpp
   SerializationTest.cpp

--- a/src/leapserial/test/LeapArchiveTest.cpp
+++ b/src/leapserial/test/LeapArchiveTest.cpp
@@ -1,11 +1,9 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
-#include <gtest/gtest.h>
-
 #include "OArchiveImpl.h"
 #include "IArchiveImpl.h"
 #include "LeapSerial.h"
-
+#include <gtest/gtest.h>
 #include <sstream>
 
 class LeapArchiveTest :

--- a/src/leapserial/test/OptionalTest.cpp
+++ b/src/leapserial/test/OptionalTest.cpp
@@ -18,6 +18,27 @@ TEST(OptionalTest, Basics) {
   ASSERT_EQ(2, copy->use_count()) << "Copy assignment did not properly invoke a destructor";
 }
 
+TEST(OptionalTest, Primitives) {
+  leap::optional<int> optInt;
+  leap::optional<float> optFloat;
+  leap::optional<double> optDouble;
+
+  optInt = 9;
+  optFloat = 1.0f;
+  optDouble = 929.4949;
+
+  ASSERT_EQ(9, *optInt);
+  ASSERT_FLOAT_EQ(1.0f, *optFloat);
+  ASSERT_DOUBLE_EQ(929.4949, *optDouble);
+}
+
+TEST(OptionalTest, Pointers) {
+  std::unique_ptr<int> data{ new int { 1001 } };
+  leap::optional<int*> val = data.get();
+  ASSERT_EQ(data.get(), *val);
+  ASSERT_EQ(1001, **val);
+}
+
 TEST(OptionalTest, DtorTest) {
   auto val = std::make_shared<int>(292);
   leap::optional<std::shared_ptr<int>> optVal;

--- a/src/leapserial/test/OptionalTest.cpp
+++ b/src/leapserial/test/OptionalTest.cpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "optional.h"
+#include <gtest/gtest.h>
+#include <sstream>
+
+TEST(OptionalTest, Basics) {
+  leap::optional<std::shared_ptr<int>> optional;
+  ASSERT_FALSE(optional) << "Optional field was incorrectly initialized to a valid state";
+  optional = std::make_shared<int>(55);
+  ASSERT_EQ(55, **optional) << "Optional field did not hold an optional type properly";
+
+  leap::optional<std::shared_ptr<int>> copy;
+  copy = optional;
+  ASSERT_EQ(55, **copy) << "Copy assignment did not copy over properly";
+  copy = optional;
+  ASSERT_EQ(55, **copy) << "Copy to an existing assignment did not copy over properly";
+  ASSERT_EQ(2, copy->use_count()) << "Copy assignment did not properly invoke a destructor";
+}
+
+TEST(OptionalTest, DtorTest) {
+  auto val = std::make_shared<int>(292);
+  leap::optional<std::shared_ptr<int>> optVal;
+  optVal = val;
+
+  ASSERT_EQ(2UL, val.use_count()) << "Value was not copied properly into an optional field";
+  ASSERT_EQ(292, **optVal) << "Optional value did not point to the correct destination";
+  optVal = {};
+  ASSERT_TRUE(val.unique()) << "Optional value did not correctly release resources on destruction";
+}
+
+TEST(OptionalTest, MovementTest) {
+  std::unique_ptr<int> val { new int{111} };
+  leap::optional<std::unique_ptr<int>> optVal;
+  optVal = std::move(val);
+  ASSERT_EQ(111, **optVal) << "Optional value did not correctly receive a move-only value";
+}
+
+TEST(OptionalTest, PlacementConstruct) {
+  leap::optional<std::shared_ptr<int>> optVal;
+  optVal.emplace(new int{ 1001 });
+  ASSERT_EQ(1001, **optVal) << "Optional value did not correctly placement construct a unique pointer";
+
+  auto val = *optVal;
+  ASSERT_EQ(2UL, val.use_count());
+  optVal.emplace(new int{ 2001 });
+  ASSERT_EQ(2001, **optVal) << "Optional value did not take on a new value properly in emplace while holding a value";
+  ASSERT_TRUE(val.unique()) << "Optional value did not correctly release its existing value on emplace construction";
+}
+
+TEST(OptionalTest, Swap) {
+  leap::optional<std::unique_ptr<int>> optValA{ std::unique_ptr<int>{ new int{ 7774 } } };
+  leap::optional<std::unique_ptr<int>> optValB = std::move(optValA);
+  ASSERT_FALSE(optValA) << "Moved optional not properly nullified";
+  ASSERT_TRUE(optValB) << "R-value initialized optional was unexpectedly empty";
+
+  optValB.swap(optValB);
+  ASSERT_TRUE(optValB) << "Incorrect reflexive swap behavior";
+  ASSERT_EQ(7774, **optValB) << "Incorrect reflexive swap behavior";
+
+  leap::optional<std::unique_ptr<int>> optValC;
+  std::swap(optValA, optValB);
+  std::swap(optValA, optValC);
+  ASSERT_FALSE(optValA);
+  ASSERT_FALSE(optValB);
+  ASSERT_TRUE(optValC);
+}


### PR DESCRIPTION
The STL will someday have something like this in it, then we can remove this implementation.  In the meantime, however, we need to supply one of our own in order to be compatible with the Protobuf format without incurring a pretty big performance hit.