### PR TITLE
Archive type should provide an EOF accessor

### DIFF
--- a/LeapSerial/Archive.h
+++ b/LeapSerial/Archive.h
@@ -26,6 +26,11 @@ namespace leap {
   public:
     virtual ~IInputStream(void) {}
 
+    /// <returns>
+    /// False if the next call to Read might succeed
+    /// </returns>
+    virtual bool IsEof(void) const = 0;
+
     /// <summary>
     /// Reads exactly the specified number of bytes from the input stream
     /// </summary>
@@ -58,6 +63,7 @@ namespace leap {
 
   public:
     // IInputStream overrides:
+    bool IsEof(void) const override;
     std::streamsize Read(void* pBuf, std::streamsize ncb) override;
     std::streamsize Skip(std::streamsize ncb) override;
   };

--- a/src/leapserial/Archive.cpp
+++ b/src/leapserial/Archive.cpp
@@ -5,6 +5,10 @@
 
 using namespace leap;
 
+bool InputStreamAdapter::IsEof(void) const {
+  return is.eof();
+}
+
 std::streamsize InputStreamAdapter::Read(void* pBuf, std::streamsize ncb) {
   is.read((char*)pBuf, ncb);
   return is ? is.gcount() : -1;


### PR DESCRIPTION
Without this we can't detect EOF except to read until we fail, and this causes avoidable exceptions to be thrown.