### PR TITLE
Switch Array and Dictionary methods to use an explicit interface type

### DIFF
--- a/LeapSerial/Archive.h
+++ b/LeapSerial/Archive.h
@@ -1,5 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include "IArray.h"
+#include "IDictionary.h"
 #include <cstdint>
 #include <functional>
 #include <ios>
@@ -211,29 +213,17 @@ namespace leap {
     /// <summary>
     /// Writes out an array of entries
     /// </summary>
-    virtual void WriteArray(const field_serializer& desc, uint64_t n, std::function<const void*()> enumerator) = 0;
+    virtual void WriteArray(const IArray& ary) = 0;
     
     /// <summary>
     /// Writes out a dictionary of entries
     /// </summary>
-    virtual void WriteDictionary(
-      uint64_t n,
-      const field_serializer& keyDesc,
-      std::function<const void*()> keyEnumerator,
-      const field_serializer& valueDesc,
-      std::function<const void*()> valueEnumerator
-     ) = 0;
+    virtual void WriteDictionary(IDictionaryReader&& dictionary) = 0;
 
     virtual uint64_t SizeObjectReference(const field_serializer& serializer, const void* pObj) const = 0;
     virtual uint64_t SizeDescriptor(const descriptor& descriptor, const void* pObj) const = 0;
-    virtual uint64_t SizeArray(const field_serializer& desc, uint64_t n, std::function<const void*()> enumerator) const = 0;
-    virtual uint64_t SizeDictionary(
-      uint64_t n,
-      const field_serializer& keyDesc,
-      std::function<const void*()> keyEnumerator,
-      const field_serializer& valueDesc,
-      std::function<const void*()> valueEnumerator
-      ) const = 0;
+    virtual uint64_t SizeArray(const IArray& ary) const = 0;
+    virtual uint64_t SizeDictionary(IDictionaryReader&& dictionary) const = 0;
   };
 
   class IArchive {
@@ -256,7 +246,9 @@ namespace leap {
 
     /// <summary>
     /// Reads an object into the specified memory
+    /// </summary>
     virtual void ReadObject(const field_serializer& sz, void* pObj, internal::AllocationBase* pOwner) = 0;
+
     /// <summary>
     /// Identical to IArchiveRegistry::ReadObjectReference, except this prevents the IArchive from delegating delete responsibilities to the allocation
     /// </summary>
@@ -296,11 +288,11 @@ namespace leap {
     /// <param name="charSize"> The number of bytes per character </param>
     /// <param name="getBufferFn"> Function to get the buffer to write to, takes the size of the string as an argument </param>
     virtual void ReadString(std::function<void*(uint64_t)> getBufferFn, uint8_t charSize, uint64_t ncb) = 0;
-    
+
     /// <summary>
     /// Reads out a length delimited array of an arbitrary type into the specified buffer.
     /// </summary>
-    virtual void ReadArray(std::function<void(uint64_t)> sizeBufferFn, const field_serializer& t_serializer, std::function<void*()> enumerator, uint64_t n) = 0;
+    virtual void ReadArray(IArray& ary) = 0;
 
     /// <summary>
     /// Reads the specified boolean value to the output stream
@@ -320,13 +312,7 @@ namespace leap {
     virtual uint64_t ReadInteger(uint8_t ncb) = 0;
     virtual void ReadFloat(float& value) { ReadByteArray(&value, sizeof(float)); }
     virtual void ReadFloat(double& value) { ReadByteArray(&value, sizeof(double)); }
-    virtual void ReadDictionary(const field_serializer& keyDesc,
-                                void* key,
-                                const field_serializer& valueDesc,
-                                void* value,
-                                std::function<void(const void* key, const void* value)> inserter
-                                ) = 0;
-
+    virtual void ReadDictionary(IDictionaryInserter&& dictionary) = 0;
   };
 
   /// <summary>

--- a/LeapSerial/Archive.h
+++ b/LeapSerial/Archive.h
@@ -213,7 +213,7 @@ namespace leap {
     /// <summary>
     /// Writes out an array of entries
     /// </summary>
-    virtual void WriteArray(const IArray& ary) = 0;
+    virtual void WriteArray(IArrayReader&& ary) = 0;
     
     /// <summary>
     /// Writes out a dictionary of entries
@@ -222,7 +222,7 @@ namespace leap {
 
     virtual uint64_t SizeObjectReference(const field_serializer& serializer, const void* pObj) const = 0;
     virtual uint64_t SizeDescriptor(const descriptor& descriptor, const void* pObj) const = 0;
-    virtual uint64_t SizeArray(const IArray& ary) const = 0;
+    virtual uint64_t SizeArray(IArrayReader&& ary) const = 0;
     virtual uint64_t SizeDictionary(IDictionaryReader&& dictionary) const = 0;
   };
 
@@ -292,7 +292,7 @@ namespace leap {
     /// <summary>
     /// Reads out a length delimited array of an arbitrary type into the specified buffer.
     /// </summary>
-    virtual void ReadArray(IArray& ary) = 0;
+    virtual void ReadArray(IArrayAppender&& ary) = 0;
 
     /// <summary>
     /// Reads the specified boolean value to the output stream

--- a/LeapSerial/ArchiveFlatbuffer.h
+++ b/LeapSerial/ArchiveFlatbuffer.h
@@ -47,14 +47,8 @@ namespace leap {
     void WriteObjectReference(const field_serializer& serializer, const void* pObj) override;
     void WriteObject(const field_serializer& serializer, const void* pObj) override;
     void WriteDescriptor(const descriptor& descriptor, const void* pObj) override;
-    void WriteArray(const field_serializer& desc, uint64_t n, std::function<const void*()> enumerator) override;
-    void WriteDictionary(
-      uint64_t n,
-      const field_serializer& keyDesc,
-      std::function<const void*()> keyEnumerator,
-      const field_serializer& valueDesc,
-      std::function<const void*()> valueEnumerator
-      ) override;
+    void WriteArray(const IArray& ary) override;
+    void WriteDictionary(IDictionaryReader&& dictionary) override;
 
     //Size query functions.  Note that these do not return the total size of the object,
     //but rather the size they take up in a table (sizeof(uint32_t) for objects stored by reference).
@@ -65,14 +59,8 @@ namespace leap {
     uint64_t SizeString(const void* pBuf, uint64_t ncb, uint8_t charSize) const override;
     uint64_t SizeObjectReference(const field_serializer& serializer, const void* pObj) const override;
     uint64_t SizeDescriptor(const descriptor& descriptor, const void* pObj) const override;
-    uint64_t SizeArray(const field_serializer& desc, uint64_t n, std::function<const void*()> enumerator) const override;
-    uint64_t SizeDictionary(
-      uint64_t n,
-      const field_serializer& keyDesc,
-      std::function<const void*()> keyEnumerator,
-      const field_serializer& valueDesc,
-      std::function<const void*()> valueEnumerator
-      ) const override;
+    uint64_t SizeArray(const IArray& ary) const override;
+    uint64_t SizeDictionary(IDictionaryReader&& dictionary) const override;
 
   private:
     std::ostream& os;
@@ -119,13 +107,8 @@ namespace leap {
     uint64_t ReadInteger(uint8_t ncb) override;
     void ReadFloat(float& value) override;
     void ReadFloat(double& value) override;
-    void ReadArray(std::function<void(uint64_t)> sizeBufferFn, const field_serializer& t_serializer, std::function<void*()> enumerator, uint64_t n) override;
-    void ReadDictionary(const field_serializer& keyDesc,
-      void* key,
-      const field_serializer& valueDesc,
-      void* value,
-      std::function<void(const void* key, const void* value)> inserter
-      ) override;
+    void ReadArray(IArray& ary) override;
+    void ReadDictionary(IDictionaryInserter&& dictionary) override;
 
     void* ReadObjectReference(const create_delete& cd, const field_serializer& desc) override;
 

--- a/LeapSerial/ArchiveFlatbuffer.h
+++ b/LeapSerial/ArchiveFlatbuffer.h
@@ -47,7 +47,7 @@ namespace leap {
     void WriteObjectReference(const field_serializer& serializer, const void* pObj) override;
     void WriteObject(const field_serializer& serializer, const void* pObj) override;
     void WriteDescriptor(const descriptor& descriptor, const void* pObj) override;
-    void WriteArray(const IArray& ary) override;
+    void WriteArray(IArrayReader&& ary) override;
     void WriteDictionary(IDictionaryReader&& dictionary) override;
 
     //Size query functions.  Note that these do not return the total size of the object,
@@ -59,7 +59,7 @@ namespace leap {
     uint64_t SizeString(const void* pBuf, uint64_t ncb, uint8_t charSize) const override;
     uint64_t SizeObjectReference(const field_serializer& serializer, const void* pObj) const override;
     uint64_t SizeDescriptor(const descriptor& descriptor, const void* pObj) const override;
-    uint64_t SizeArray(const IArray& ary) const override;
+    uint64_t SizeArray(IArrayReader&& ary) const override;
     uint64_t SizeDictionary(IDictionaryReader&& dictionary) const override;
 
   private:
@@ -107,7 +107,7 @@ namespace leap {
     uint64_t ReadInteger(uint8_t ncb) override;
     void ReadFloat(float& value) override;
     void ReadFloat(double& value) override;
-    void ReadArray(IArray& ary) override;
+    void ReadArray(IArrayAppender&& ary) override;
     void ReadDictionary(IDictionaryInserter&& dictionary) override;
 
     void* ReadObjectReference(const create_delete& cd, const field_serializer& desc) override;

--- a/LeapSerial/ArchiveJSON.h
+++ b/LeapSerial/ArchiveJSON.h
@@ -41,14 +41,8 @@ namespace leap {
     void WriteObjectReference(const field_serializer& serializer, const void* pObj) override;
     void WriteObject(const field_serializer& serializer, const void* pObj) override;
     void WriteDescriptor(const descriptor& descriptor, const void* pObj) override;
-    void WriteArray(const field_serializer& desc, uint64_t n, std::function<const void*()> enumerator) override;
-    void WriteDictionary(
-      uint64_t n,
-      const field_serializer& keyDesc,
-      std::function<const void*()> keyEnumerator,
-      const field_serializer& valueDesc,
-      std::function<const void*()> valueEnumerator
-    ) override;
+    void WriteArray(const IArray& ary) override;
+    void WriteDictionary(IDictionaryReader&& dictionary) override;
 
     //Size query functions.  Note that these do not return the total size of the object,
     //but rather the size they take up in a table (sizeof(uint32_t) for objects stored by reference).
@@ -59,14 +53,8 @@ namespace leap {
     uint64_t SizeString(const void* pBuf, uint64_t ncb, uint8_t charSize) const override;
     uint64_t SizeObjectReference(const field_serializer& serializer, const void* pObj) const override;
     uint64_t SizeDescriptor(const descriptor& descriptor, const void* pObj) const override;
-    uint64_t SizeArray(const field_serializer& desc, uint64_t n, std::function<const void*()> enumerator) const override;
-    uint64_t SizeDictionary(
-      uint64_t n,
-      const field_serializer& keyDesc,
-      std::function<const void*()> keyEnumerator,
-      const field_serializer& valueDesc,
-      std::function<const void*()> valueEnumerator
-    ) const override;
+    uint64_t SizeArray(const IArray& ary) const override;
+    uint64_t SizeDictionary(IDictionaryReader&& dictionary) const override;
 
   private:
     // Current tab level, if pretty printing is turned on, otherwise ignored
@@ -96,13 +84,8 @@ namespace leap {
     uint64_t ReadInteger(uint8_t ncb) override;
     void ReadFloat(float& value) override;
     void ReadFloat(double& value) override;
-    void ReadArray(std::function<void(uint64_t)> sizeBufferFn, const field_serializer& t_serializer, std::function<void*()> enumerator, uint64_t n) override;
-    void ReadDictionary(const field_serializer& keyDesc,
-      void* key,
-      const field_serializer& valueDesc,
-      void* value,
-      std::function<void(const void* key, const void* value)> inserter
-      ) override;
+    void ReadArray(IArray& ary) override;
+    void ReadDictionary(IDictionaryInserter&& dictionary) override;
 
     void* ReadObjectReference(const create_delete& cd, const field_serializer& desc) override;
   };

--- a/LeapSerial/ArchiveJSON.h
+++ b/LeapSerial/ArchiveJSON.h
@@ -41,7 +41,7 @@ namespace leap {
     void WriteObjectReference(const field_serializer& serializer, const void* pObj) override;
     void WriteObject(const field_serializer& serializer, const void* pObj) override;
     void WriteDescriptor(const descriptor& descriptor, const void* pObj) override;
-    void WriteArray(const IArray& ary) override;
+    void WriteArray(IArrayReader&& ary) override;
     void WriteDictionary(IDictionaryReader&& dictionary) override;
 
     //Size query functions.  Note that these do not return the total size of the object,
@@ -53,7 +53,7 @@ namespace leap {
     uint64_t SizeString(const void* pBuf, uint64_t ncb, uint8_t charSize) const override;
     uint64_t SizeObjectReference(const field_serializer& serializer, const void* pObj) const override;
     uint64_t SizeDescriptor(const descriptor& descriptor, const void* pObj) const override;
-    uint64_t SizeArray(const IArray& ary) const override;
+    uint64_t SizeArray(IArrayReader&& ary) const override;
     uint64_t SizeDictionary(IDictionaryReader&& dictionary) const override;
 
   private:
@@ -84,7 +84,7 @@ namespace leap {
     uint64_t ReadInteger(uint8_t ncb) override;
     void ReadFloat(float& value) override;
     void ReadFloat(double& value) override;
-    void ReadArray(IArray& ary) override;
+    void ReadArray(IArrayAppender&& ary) override;
     void ReadDictionary(IDictionaryInserter&& dictionary) override;
 
     void* ReadObjectReference(const create_delete& cd, const field_serializer& desc) override;

--- a/LeapSerial/IArchiveImpl.h
+++ b/LeapSerial/IArchiveImpl.h
@@ -107,16 +107,7 @@ namespace leap {
     void ReadFloat(float& value) override { ReadByteArray(&value, sizeof(float)); }
     void ReadFloat(double& value) override { ReadByteArray(&value, sizeof(double)); }
     void ReadDescriptor(const descriptor& descriptor, void* pObj, uint64_t ncb) override;
-    void ReadArray(std::function<void(uint64_t)> sizeBufferFn, const field_serializer& t_serializer, std::function<void*()> enumerator, uint64_t n) override;
-    void ReadDictionary(const field_serializer& keyDesc,
-                        void* key,
-                        const field_serializer& valueDesc,
-                        void* value,
-                        std::function<void(const void* key, const void* value)> insertionFn
-                        ) override;
-
-    
-
-
+    void ReadArray(IArray& ary) override;
+    void ReadDictionary(IDictionaryInserter&& dictionary) override;
   };
 }

--- a/LeapSerial/IArchiveImpl.h
+++ b/LeapSerial/IArchiveImpl.h
@@ -107,7 +107,7 @@ namespace leap {
     void ReadFloat(float& value) override { ReadByteArray(&value, sizeof(float)); }
     void ReadFloat(double& value) override { ReadByteArray(&value, sizeof(double)); }
     void ReadDescriptor(const descriptor& descriptor, void* pObj, uint64_t ncb) override;
-    void ReadArray(IArray& ary) override;
+    void ReadArray(IArrayAppender&& ary) override;
     void ReadDictionary(IDictionaryInserter&& dictionary) override;
   };
 }

--- a/LeapSerial/IArray.h
+++ b/LeapSerial/IArray.h
@@ -4,8 +4,8 @@
 namespace leap {
   struct field_serializer;
 
-  struct IArray {
-    IArray(const field_serializer& serializer) :
+  struct IArrayReader {
+    IArrayReader(const field_serializer& serializer) :
       serializer(serializer)
     {}
 
@@ -23,6 +23,17 @@ namespace leap {
     /// The size of the array object
     /// </returns>
     virtual size_t size(void) const = 0;
+  };
+
+  struct IArrayAppender {
+    IArrayAppender(const field_serializer& serializer) :
+      serializer(serializer)
+    {}
+
+    /// <summary>
+    /// The serializer for elements of the array
+    /// </summary>
+    const field_serializer& serializer;
 
     /// <summary>
     /// Reserves the specified number of entries in the array

--- a/LeapSerial/IArray.h
+++ b/LeapSerial/IArray.h
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 namespace leap {

--- a/LeapSerial/IArray.h
+++ b/LeapSerial/IArray.h
@@ -1,0 +1,39 @@
+#pragma once
+
+namespace leap {
+  struct field_serializer;
+
+  struct IArray {
+    IArray(const field_serializer& serializer) :
+      serializer(serializer)
+    {}
+
+    /// <summary>
+    /// The serializer for elements of the array
+    /// </summary>
+    const field_serializer& serializer;
+
+    /// <returns>
+    /// The ith item in the specified array
+    /// </returns>
+    virtual const void* get(size_t i) const = 0;
+
+    /// <returns>
+    /// The size of the array object
+    /// </returns>
+    virtual size_t size(void) const = 0;
+
+    /// <summary>
+    /// Reserves the specified number of entries in the array
+    /// </summary>
+    virtual void reserve(size_t n) = 0;
+
+    /// <summary>
+    /// Allocates a space for a new entry in the array
+    /// </summary>
+    /// <remarks>
+    /// The returned space must be default-constructed or otherwise valid
+    /// </remarks>
+    virtual void* allocate(void) = 0;
+  };
+}

--- a/LeapSerial/IArray.h
+++ b/LeapSerial/IArray.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include <cstddef>
 
 namespace leap {
   struct field_serializer;

--- a/LeapSerial/IDictionary.h
+++ b/LeapSerial/IDictionary.h
@@ -1,0 +1,79 @@
+#pragma once
+
+namespace leap {
+  /// <summary>
+  /// An interface to describe read operations related to a dictionary
+  /// </summary>
+  struct IDictionaryReader {
+    IDictionaryReader(const field_serializer& key_serializer, const field_serializer& value_serializer) :
+      key_serializer(key_serializer),
+      value_serializer(value_serializer)
+    {}
+
+    /// <summary>
+    /// The serializer for keys in this dictionary
+    /// </summary>
+    const field_serializer& key_serializer;
+
+    /// <returns>
+    /// The serializer for values in this dictionary
+    /// </returns>
+    const field_serializer& value_serializer;
+
+    /// <returns>
+    /// The size of the passed dictionary object
+    /// </returns>
+    virtual size_t size(void) const = 0;
+
+    /// <summary>
+    /// Advances to the next entry in the dictionary.
+    /// </summary>
+    /// <returns>False if there were no other elements</returns>
+    /// <remarks>
+    /// This method must be called before the first call to `key` or `value`
+    /// </remarks>
+    virtual bool next(void) = 0;
+
+    /// <returns>The currently enumerated key</returns>
+    virtual const void* key(void) const = 0;
+
+    /// <returns>The currently enumerated value</returns>
+    virtual const void* value(void) const = 0;
+  };
+
+  /// <summary>
+  /// An interface to describe read operations related to a dictionary
+  /// </summary>
+  struct IDictionaryInserter {
+    /// <returns>
+    /// </returns>
+    IDictionaryInserter(const field_serializer& key_serializer, const field_serializer& value_serializer) :
+      key_serializer(key_serializer),
+      value_serializer(value_serializer)
+    {}
+
+    /// <summary>
+    /// The serializer for keys in this dictionary
+    /// </summary>
+    const field_serializer& key_serializer;
+
+    /// <returns>
+    /// The serializer for values in this dictionary
+    /// </returns>
+    const field_serializer& value_serializer;
+
+    /// <summary>
+    /// Retrieves a space that may be used to insert a key
+    /// </summary>
+    virtual void* key(void) = 0;
+
+    /// <summary>
+    /// Creates a space for the specified key in the dictionary
+    /// </summary>
+    /// <returns>The value counterpart for the key</returns>
+    /// <remarks>
+    /// The key space is reset on this insert call.
+    /// </remarks>
+    virtual void* insert(void) = 0;
+  };
+}

--- a/LeapSerial/IDictionary.h
+++ b/LeapSerial/IDictionary.h
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 namespace leap {

--- a/LeapSerial/IDictionary.h
+++ b/LeapSerial/IDictionary.h
@@ -1,7 +1,10 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include <cstddef>
 
 namespace leap {
+  struct field_serializer;
+
   /// <summary>
   /// An interface to describe read operations related to a dictionary
   /// </summary>

--- a/LeapSerial/OArchiveImpl.h
+++ b/LeapSerial/OArchiveImpl.h
@@ -75,13 +75,13 @@ namespace leap {
     void WriteString(const void* pbuf, uint64_t charCount, uint8_t charSize) override;
     void WriteBool(bool value) override;
     void WriteInteger(int64_t value, uint8_t ncb) override;
-    void WriteArray(const field_serializer& desc, uint64_t n, std::function<const void*()> enumerator) override;
-    void WriteDictionary(uint64_t n, const field_serializer& keyDesc, std::function<const void*()> keyEnumerator, const field_serializer& valueDesc, std::function<const void*()> valueEnumerator) override;
+    void WriteArray(const IArray& ary) override;
+    void WriteDictionary(IDictionaryReader&& dictionary) override;
     
     uint64_t SizeDescriptor(const descriptor& desc, const void* pObj) const override;
     uint64_t SizeObjectReference(const field_serializer&, const void*) const override { return sizeof(uint32_t); }
-    uint64_t SizeArray(const field_serializer& desc, uint64_t n, std::function<const void*()> enumerator) const override;
-    uint64_t SizeDictionary(uint64_t n, const field_serializer& keyDesc, std::function<const void*()> keyEnumerator, const field_serializer& valueDesc, std::function<const void*()> valueEnumerator) const override;
+    uint64_t SizeArray(const IArray& ary) const override;
+    uint64_t SizeDictionary(IDictionaryReader&& dictionary) const override;
     
     inline uint64_t SizeString(const void* pBuf, uint64_t charCount, uint8_t charSize) const override { return (size_t)(sizeof(uint32_t) + (charCount*charSize)); }
     uint64_t SizeInteger(int64_t value, uint8_t ncb) const override;

--- a/LeapSerial/OArchiveImpl.h
+++ b/LeapSerial/OArchiveImpl.h
@@ -75,12 +75,12 @@ namespace leap {
     void WriteString(const void* pbuf, uint64_t charCount, uint8_t charSize) override;
     void WriteBool(bool value) override;
     void WriteInteger(int64_t value, uint8_t ncb) override;
-    void WriteArray(const IArray& ary) override;
+    void WriteArray(IArrayReader&& ary) override;
     void WriteDictionary(IDictionaryReader&& dictionary) override;
     
     uint64_t SizeDescriptor(const descriptor& desc, const void* pObj) const override;
     uint64_t SizeObjectReference(const field_serializer&, const void*) const override { return sizeof(uint32_t); }
-    uint64_t SizeArray(const IArray& ary) const override;
+    uint64_t SizeArray(IArrayReader&& ary) const override;
     uint64_t SizeDictionary(IDictionaryReader&& dictionary) const override;
     
     inline uint64_t SizeString(const void* pBuf, uint64_t charCount, uint8_t charSize) const override { return (size_t)(sizeof(uint32_t) + (charCount*charSize)); }

--- a/LeapSerial/serial_traits.h
+++ b/LeapSerial/serial_traits.h
@@ -151,36 +151,61 @@ namespace leap {
   template<typename T, size_t N>
   struct primitive_serial_traits<T[N], typename std::enable_if<has_serializer<T>::value>::type>
   {
+    struct CArrayImpl :
+      public IArray
+    {
+      CArrayImpl(const T* pAry) :
+        IArray(field_serializer_t<T, void>::GetDescriptor()),
+        pAry(pAry)
+      {}
+
+      const T* const pAry;
+      size_t i = 0;
+
+      const void* get(size_t i) const override { return pAry + i; }
+      size_t size(void) const override { return N; }
+      void reserve(size_t n) override { throw std::runtime_error("Attempted to access a non-const member on a constant type"); }
+      void* allocate(void) override { throw std::runtime_error("Attempted to access a non-const member on a constant type"); }
+    };
+
+    struct ArrayImpl :
+      public IArray
+    {
+      ArrayImpl(T* pAry) :
+        IArray(field_serializer_t<T, void>::GetDescriptor()),
+        pAry(pAry)
+      {}
+
+      T* const pAry;
+      size_t i = 0;
+
+      const void* get(size_t i) const override { return pAry + i; }
+      size_t size(void) const override { return N; }
+
+      void reserve(size_t n) override {
+        if (n != N)
+          throw std::runtime_error("Incorrect deserialization attempt into a non-fixed-size space");
+      }
+
+      void* allocate(void) override {
+        return pAry + i++;
+      };
+    };
+
     static ::leap::serial_atom type() {
       return ::leap::serial_atom::array;
     }
 
     static uint64_t size(const OArchiveRegistry& ar, const T* pObj) {
-      size_t i = 0;
-      return ar.SizeArray(
-        field_serializer_t<T,void>::GetDescriptor(),
-        N,
-        [&] {return &pObj[i++]; }
-      );
+      return ar.SizeArray(CArrayImpl{ pObj });
     }
 
     static void serialize(OArchiveRegistry& ar, const T* pObj) {
-      size_t i = 0;
-      ar.WriteArray(
-        field_serializer_t<T,void>::GetDescriptor(),
-        N,
-        [&]{ return &pObj[i++]; }
-      );
+      ar.WriteArray(CArrayImpl{ pObj });
     }
 
     static void deserialize(IArchiveRegistry& ar, T* pObj, uint64_t ncb) {
-      size_t i = 0;
-      ar.ReadArray(
-        [](uint64_t){},
-        field_serializer_t<T, void>::GetDescriptor(),
-        [&](){ return &pObj[i++]; },
-        N
-      );
+      ar.ReadArray(ArrayImpl{ pObj });
     }
   };
 
@@ -231,6 +256,43 @@ namespace leap {
   template<typename T, typename Alloc>
   struct primitive_serial_traits<std::vector<T, Alloc>, typename std::enable_if<has_serializer<T>::value>::type>
   {
+    typedef std::vector<T, Alloc> serial_type;
+
+    struct CArrayImpl :
+      IArray
+    {
+      CArrayImpl(const serial_type& obj) :
+        IArray(field_serializer_t<T, void>::GetDescriptor()),
+        obj(obj)
+      {}
+
+      const serial_type& obj;
+
+      const void* get(size_t i) const override { return &obj[i]; }
+      size_t size(void) const override { return obj.size(); }
+      void reserve(size_t n) override { throw std::runtime_error("Attempted to access a non-const member on a constant type"); }
+      void* allocate(void) override { throw std::runtime_error("Attempted to access a non-const member on a constant type"); }
+    };
+
+    struct ArrayImpl :
+      IArray
+    {
+      ArrayImpl(serial_type& obj) :
+        IArray(field_serializer_t<T, void>::GetDescriptor()),
+        obj(obj)
+      {}
+
+      serial_type& obj;
+
+      const void* get(size_t i) const override { return &obj[i]; }
+      size_t size(void) const override { return obj.size(); }
+      void reserve(size_t n) override { obj.reserve(n); }
+      void* allocate(void) override {
+        obj.push_back({});
+        return &obj.back();
+      }
+    };
+
     static ::leap::serial_atom type() {
       return ::leap::serial_atom::array;
     }
@@ -241,32 +303,16 @@ namespace leap {
     // If we're irresponsible, we need a more powerful archive registry as an input
     typedef typename std::conditional<is_irresponsible, IArchiveRegistry, IArchive>::type iarchive;
 
-    static uint64_t size(const OArchiveRegistry& ar, const std::vector<T, Alloc>& v) {
-      size_t i = 0;
-      return ar.SizeArray(
-        field_serializer_t<T,void>::GetDescriptor(),
-        v.size(),
-        [&] { return &v[i++]; }
-      );
+    static uint64_t size(const OArchiveRegistry& ar, const serial_type& v) {
+      return ar.SizeArray(CArrayImpl{ v });
     }
 
-    static void serialize(OArchiveRegistry& ar, const std::vector<T, Alloc>& v) {
-      size_t i = 0;
-      ar.WriteArray(
-        field_serializer_t<T,void>::GetDescriptor(),
-        static_cast<uint64_t>(v.size()),
-        [&] { return &v[i++]; }
-      );
+    static void serialize(OArchiveRegistry& ar, const serial_type& v) {
+      ar.WriteArray(CArrayImpl{ v });
     }
 
-    static void deserialize(iarchive& ar, std::vector<T, Alloc>& v, uint64_t ncb) {
-      size_t i = 0;
-      ar.ReadArray(
-        [&](uint64_t sz){ v.resize((uint32_t)sz); },
-        field_serializer_t<T, void>::GetDescriptor(),
-        [&] { return &v[i++]; },
-        0
-      );
+    static void deserialize(iarchive& ar, serial_type& v, uint64_t ncb) {
+      ar.ReadArray(ArrayImpl{ v });
     }
   };
 
@@ -292,45 +338,72 @@ namespace leap {
     // type in order to ensure values are correctly propagated.
     typedef typename std::conditional<sc_needsAllocation, IArchiveRegistry, IArchive>::type iarchive;
 
+    struct DictionaryReaderImpl :
+      IDictionaryReader
+    {
+      DictionaryReaderImpl(const Container& container) :
+        IDictionaryReader(
+          field_serializer_t<key_type, void>::GetDescriptor(),
+          field_serializer_t<mapped_type, void>::GetDescriptor()
+        ),
+        container(container),
+        q(container.end())
+      {}
+
+      const Container& container;
+      bool init = false;
+      typename Container::const_iterator q;
+
+      size_t size(void) const override { return container.size(); }
+      bool next(void) {
+        if (init)
+          ++q;
+        else {
+          init = true;
+          q = container.begin();
+        }
+        return q != container.end();
+      }
+      const void* key(void) const { return &q->first; }
+      const void* value(void) const { return &q->second; }
+    };
+
+    struct DictionaryInserterImpl :
+      IDictionaryInserter
+    {
+      DictionaryInserterImpl(Container& container) :
+        IDictionaryInserter(
+          field_serializer_t<key_type, void>::GetDescriptor(),
+          field_serializer_t<mapped_type, void>::GetDescriptor()
+        ),
+        container(container)
+      {}
+
+      Container& container;
+      key_type m_key;
+
+      void* key(void) override { return &m_key; }
+      void* insert(void) override {
+        void* retVal = &container[std::move(m_key)];
+        m_key = key_type{};
+        return retVal;
+      }
+    };
+
     static ::leap::serial_atom type() {
       return ::leap::serial_atom::map;
     }
 
     static uint64_t size(const OArchiveRegistry& ar, const Container& obj) {
-      auto iKey = obj.begin();
-      auto iValue = obj.begin();
-      return ar.SizeDictionary(obj.size(),
-        field_serializer_t<key_type, void>::GetDescriptor(),
-        [&]{ return &(iKey++)->first; },
-        field_serializer_t<mapped_type, void>::GetDescriptor(),
-        [&]{ return &(iValue++)->second;
-      }
-      );
+      return ar.SizeDictionary(DictionaryReaderImpl{ obj });
     }
 
     static void serialize(OArchiveRegistry& ar, const Container& obj) {
-      auto iKey = obj.begin();
-      auto iValue = obj.begin();
-      return ar.WriteDictionary(obj.size(),
-        field_serializer_t<key_type, void>::GetDescriptor(),
-        [&]{ return &((iKey++)->first); },
-        field_serializer_t<mapped_type, void>::GetDescriptor(),
-        [&]{ return &((iValue++)->second); }
-      );
+      return ar.WriteDictionary(DictionaryReaderImpl{ obj });
     }
 
     static void deserialize(iarchive& ar, Container& obj, uint64_t ncb) {
-      typename Container::key_type key;
-      typename Container::mapped_type value;
-      ar.ReadDictionary(
-        field_serializer_t<key_type,void>::GetDescriptor(),
-        &key,
-        field_serializer_t<mapped_type,void>::GetDescriptor(),
-        &value,
-        [&](const void* keyIn, const void* valueIn) {
-          obj.emplace(*reinterpret_cast<const key_type*>(keyIn), *reinterpret_cast<const mapped_type*>(valueIn));
-        }
-      );
+      ar.ReadDictionary(DictionaryInserterImpl{ obj });
     }
   };
   

--- a/LeapSerial/serial_traits.h
+++ b/LeapSerial/serial_traits.h
@@ -152,35 +152,29 @@ namespace leap {
   struct primitive_serial_traits<T[N], typename std::enable_if<has_serializer<T>::value>::type>
   {
     struct CArrayImpl :
-      public IArray
+      public IArrayReader
     {
       CArrayImpl(const T* pAry) :
-        IArray(field_serializer_t<T, void>::GetDescriptor()),
+        IArrayReader(field_serializer_t<T, void>::GetDescriptor()),
         pAry(pAry)
       {}
 
       const T* const pAry;
-      size_t i = 0;
 
       const void* get(size_t i) const override { return pAry + i; }
       size_t size(void) const override { return N; }
-      void reserve(size_t n) override { throw std::runtime_error("Attempted to access a non-const member on a constant type"); }
-      void* allocate(void) override { throw std::runtime_error("Attempted to access a non-const member on a constant type"); }
     };
 
     struct ArrayImpl :
-      public IArray
+      public IArrayAppender
     {
       ArrayImpl(T* pAry) :
-        IArray(field_serializer_t<T, void>::GetDescriptor()),
+        IArrayAppender(field_serializer_t<T, void>::GetDescriptor()),
         pAry(pAry)
       {}
 
       T* const pAry;
       size_t i = 0;
-
-      const void* get(size_t i) const override { return pAry + i; }
-      size_t size(void) const override { return N; }
 
       void reserve(size_t n) override {
         if (n != N)
@@ -259,10 +253,10 @@ namespace leap {
     typedef std::vector<T, Alloc> serial_type;
 
     struct CArrayImpl :
-      IArray
+      IArrayReader
     {
       CArrayImpl(const serial_type& obj) :
-        IArray(field_serializer_t<T, void>::GetDescriptor()),
+        IArrayReader(field_serializer_t<T, void>::GetDescriptor()),
         obj(obj)
       {}
 
@@ -270,22 +264,18 @@ namespace leap {
 
       const void* get(size_t i) const override { return &obj[i]; }
       size_t size(void) const override { return obj.size(); }
-      void reserve(size_t n) override { throw std::runtime_error("Attempted to access a non-const member on a constant type"); }
-      void* allocate(void) override { throw std::runtime_error("Attempted to access a non-const member on a constant type"); }
     };
 
     struct ArrayImpl :
-      IArray
+      IArrayAppender
     {
       ArrayImpl(serial_type& obj) :
-        IArray(field_serializer_t<T, void>::GetDescriptor()),
+        IArrayAppender(field_serializer_t<T, void>::GetDescriptor()),
         obj(obj)
       {}
 
       serial_type& obj;
 
-      const void* get(size_t i) const override { return &obj[i]; }
-      size_t size(void) const override { return obj.size(); }
       void reserve(size_t n) override { obj.reserve(n); }
       void* allocate(void) override {
         obj.push_back({});

--- a/src/leapserial/ArchiveFlatbuffer.cpp
+++ b/src/leapserial/ArchiveFlatbuffer.cpp
@@ -246,7 +246,7 @@ void OArchiveFlatbuffer::WriteDescriptor(const descriptor& descriptor, const voi
   WriteInteger(vTable.size);
 }
 
-void OArchiveFlatbuffer::WriteArray(const IArray& ary) { 
+void OArchiveFlatbuffer::WriteArray(IArrayReader&& ary) {
   //We need to write these twice in some cases, so store the pointers & go back through in reverse
   std::vector<const void*> elements;
   size_t n = ary.size();
@@ -307,7 +307,7 @@ uint64_t OArchiveFlatbuffer::SizeDescriptor(const descriptor& descriptor, const 
   return sizeof(uint32_t);
 }
 
-uint64_t OArchiveFlatbuffer::SizeArray(const IArray& ary) const { 
+uint64_t OArchiveFlatbuffer::SizeArray(IArrayReader&& ary) const { 
   return sizeof(uint32_t);
 }
 
@@ -427,7 +427,7 @@ void IArchiveFlatbuffer::ReadFloat(double& value) {
   m_offset += sizeof(float);
 }
 
-void IArchiveFlatbuffer::ReadArray(IArray& ary) {
+void IArchiveFlatbuffer::ReadArray(IArrayAppender&& ary) {
   const auto baseOffset = m_offset;
   const auto arrayOffset = baseOffset + GetValue<uint32_t>(baseOffset);
 

--- a/src/leapserial/ArchiveFlatbuffer.cpp
+++ b/src/leapserial/ArchiveFlatbuffer.cpp
@@ -246,21 +246,22 @@ void OArchiveFlatbuffer::WriteDescriptor(const descriptor& descriptor, const voi
   WriteInteger(vTable.size);
 }
 
-void OArchiveFlatbuffer::WriteArray(const field_serializer& desc, uint64_t n, std::function<const void*()> enumerator) { 
+void OArchiveFlatbuffer::WriteArray(const IArray& ary) { 
   //We need to write these twice in some cases, so store the pointers & go back through in reverse
   std::vector<const void*> elements;
-  for (uint64_t i = 0; i < n; i++)
-    elements.push_back(enumerator());
+  size_t n = ary.size();
+  for (size_t i = 0; i < n; i++)
+    elements.push_back(ary.get(i));
 
   const auto arrayPtr = m_currentFieldPtr;
 
   for (auto i = elements.rbegin(); i != elements.rend(); i++) {
     m_currentFieldPtr = *i;
-    desc.serialize(*this, *i);
+    ary.serializer.serialize(*this, *i);
   }
 
   //If this is an array of a type that is stored by offset, store the offsets...
-  if (WillStoreAsOffset(*this, desc, elements[0])) {
+  if (WillStoreAsOffset(*this, ary.serializer, elements[0])) {
     for (auto i = elements.rbegin(); i != elements.rend(); i++) {
       WriteRelativeOffset(*i);
     }
@@ -270,13 +271,7 @@ void OArchiveFlatbuffer::WriteArray(const field_serializer& desc, uint64_t n, st
   SaveOffset(arrayPtr, (uint32_t)m_builder.size());
 }
 
-void OArchiveFlatbuffer::WriteDictionary(
-  uint64_t n,
-  const field_serializer& keyDesc,
-  std::function<const void*()> keyEnumerator,
-  const field_serializer& valueDesc,
-  std::function<const void*()> valueEnumerator
-  )
+void OArchiveFlatbuffer::WriteDictionary(IDictionaryReader&& dictionary)
 { 
   throw not_implemented_exception();
 }
@@ -312,17 +307,11 @@ uint64_t OArchiveFlatbuffer::SizeDescriptor(const descriptor& descriptor, const 
   return sizeof(uint32_t);
 }
 
-uint64_t OArchiveFlatbuffer::SizeArray(const field_serializer& desc, uint64_t n, std::function<const void*()> enumerator) const { 
+uint64_t OArchiveFlatbuffer::SizeArray(const IArray& ary) const { 
   return sizeof(uint32_t);
 }
 
-uint64_t OArchiveFlatbuffer::SizeDictionary(
-  uint64_t n,
-  const field_serializer& keyDesc,
-  std::function<const void*()> keyEnumerator,
-  const field_serializer& valueDesc,
-  std::function<const void*()> valueEnumerator
-  ) const 
+uint64_t OArchiveFlatbuffer::SizeDictionary(IDictionaryReader&& dictionary) const
 { 
   throw not_implemented_exception();
 }
@@ -438,24 +427,20 @@ void IArchiveFlatbuffer::ReadFloat(double& value) {
   m_offset += sizeof(float);
 }
 
-void IArchiveFlatbuffer::ReadArray(std::function<void(uint64_t)> sizeBufferFn, const field_serializer& t_serializer, std::function<void*()> enumerator, uint64_t expectedEntries) {
+void IArchiveFlatbuffer::ReadArray(IArray& ary) {
   const auto baseOffset = m_offset;
   const auto arrayOffset = baseOffset + GetValue<uint32_t>(baseOffset);
 
   const auto size = GetValue<uint32_t>(arrayOffset);
-
-  sizeBufferFn(size);
+  ary.reserve(size);
 
   m_offset = arrayOffset + sizeof(uint32_t);
-  //const auto step = GetFieldSize(t_serializer.type());
-  for (uint32_t i = 0 ; i < size; ++i) {
-    //assert(m_offset == arrayOffset + sizeof(uint32_t) + (i * step));
-    t_serializer.deserialize(*this, enumerator(), 0);
-  }
+  for (uint32_t i = 0 ; i < size; ++i)
+    ary.serializer.deserialize(*this, ary.allocate(), 0);
 
   m_offset = baseOffset + sizeof(uint32_t);
 }
 
-void IArchiveFlatbuffer::ReadDictionary(const field_serializer& keyDesc, void* key, const field_serializer& valueDesc, void* value, std::function<void(const void* key, const void* value)> inserter) {
+void IArchiveFlatbuffer::ReadDictionary(IDictionaryInserter&& dictionary) {
   throw not_implemented_exception();
 }

--- a/src/leapserial/ArchiveJSON.cpp
+++ b/src/leapserial/ArchiveJSON.cpp
@@ -143,17 +143,11 @@ void OArchiveJSON::WriteDescriptor(const descriptor& descriptor, const void* pOb
   os << '}';
 }
 
-void OArchiveJSON::WriteArray(const field_serializer& desc, uint64_t n, std::function<const void*()> enumerator) {
+void OArchiveJSON::WriteArray(const IArray& ary) {
   throw not_implemented_exception();
 }
 
-void OArchiveJSON::WriteDictionary(
-  uint64_t n,
-  const field_serializer& keyDesc,
-  std::function<const void*()> keyEnumerator,
-  const field_serializer& valueDesc,
-  std::function<const void*()> valueEnumerator
-  )
+void OArchiveJSON::WriteDictionary(IDictionaryReader&& dictionary)
 {
   throw not_implemented_exception();
 }
@@ -180,17 +174,11 @@ uint64_t OArchiveJSON::SizeDescriptor(const descriptor& descriptor, const void* 
   throw not_implemented_exception();
 }
 
-uint64_t OArchiveJSON::SizeArray(const field_serializer& desc, uint64_t n, std::function<const void*()> enumerator) const {
+uint64_t OArchiveJSON::SizeArray(const IArray& ary) const {
   throw not_implemented_exception();
 }
 
-uint64_t OArchiveJSON::SizeDictionary(
-  uint64_t n,
-  const field_serializer& keyDesc,
-  std::function<const void*()> keyEnumerator,
-  const field_serializer& valueDesc,
-  std::function<const void*()> valueEnumerator
-  ) const
+uint64_t OArchiveJSON::SizeDictionary(IDictionaryReader&& dictionary) const
 {
   throw not_implemented_exception();
 }
@@ -252,10 +240,10 @@ void IArchiveJSON::ReadFloat(double& value) {
   throw not_implemented_exception();
 }
 
-void IArchiveJSON::ReadArray(std::function<void(uint64_t)> sizeBufferFn, const field_serializer& t_serializer, std::function<void*()> enumerator, uint64_t expectedEntries) {
+void IArchiveJSON::ReadArray(IArray& ary) {
   throw not_implemented_exception();
 }
 
-void IArchiveJSON::ReadDictionary(const field_serializer& keyDesc, void* key, const field_serializer& valueDesc, void* value, std::function<void(const void* key, const void* value)> inserter) {
+void IArchiveJSON::ReadDictionary(IDictionaryInserter&& dictionary) {
   throw not_implemented_exception();
 }

--- a/src/leapserial/ArchiveJSON.cpp
+++ b/src/leapserial/ArchiveJSON.cpp
@@ -143,7 +143,7 @@ void OArchiveJSON::WriteDescriptor(const descriptor& descriptor, const void* pOb
   os << '}';
 }
 
-void OArchiveJSON::WriteArray(const IArray& ary) {
+void OArchiveJSON::WriteArray(IArrayReader&& ary) {
   throw not_implemented_exception();
 }
 
@@ -174,7 +174,7 @@ uint64_t OArchiveJSON::SizeDescriptor(const descriptor& descriptor, const void* 
   throw not_implemented_exception();
 }
 
-uint64_t OArchiveJSON::SizeArray(const IArray& ary) const {
+uint64_t OArchiveJSON::SizeArray(IArrayReader&& ary) const {
   throw not_implemented_exception();
 }
 
@@ -240,7 +240,7 @@ void IArchiveJSON::ReadFloat(double& value) {
   throw not_implemented_exception();
 }
 
-void IArchiveJSON::ReadArray(IArray& ary) {
+void IArchiveJSON::ReadArray(IArrayAppender&& ary) {
   throw not_implemented_exception();
 }
 

--- a/src/leapserial/CMakeLists.txt
+++ b/src/leapserial/CMakeLists.txt
@@ -16,6 +16,8 @@ set(LeapSerial_SRCS
   ProtobufType.h
   IArchiveImpl.h
   IArchiveImpl.cpp
+  IArray.h
+  IDictionary.h
   OArchiveImpl.h
   OArchiveImpl.cpp
   optional.h

--- a/src/leapserial/IArchiveImpl.cpp
+++ b/src/leapserial/IArchiveImpl.cpp
@@ -150,7 +150,7 @@ void IArchiveImpl::ReadDescriptor(const descriptor& descriptor, void* pObj, uint
   }
 }
 
-void IArchiveImpl::ReadArray(IArray& ary) {
+void IArchiveImpl::ReadArray(IArrayAppender&& ary) {
   // Read the number of entries first:
   uint32_t nEntries;
   ReadByteArray(&nEntries, sizeof(nEntries));

--- a/src/leapserial/IArchiveImpl.cpp
+++ b/src/leapserial/IArchiveImpl.cpp
@@ -150,19 +150,15 @@ void IArchiveImpl::ReadDescriptor(const descriptor& descriptor, void* pObj, uint
   }
 }
 
-void IArchiveImpl::ReadArray(std::function<void(uint64_t)> sizeBufferFn, const field_serializer& t_serializer, std::function<void*()> enumerator, uint64_t expectedEntries) {
+void IArchiveImpl::ReadArray(IArray& ary) {
   // Read the number of entries first:
   uint32_t nEntries;
   ReadByteArray(&nEntries, sizeof(nEntries));
-  
-  if (expectedEntries != 0 && nEntries != expectedEntries)
-    // We expected to get N entries, but got back some other value.  Something is wrong.
-    throw std::runtime_error("Attempted to deserialize a non-matching number of entries into a fixed-size space");
-  
-  sizeBufferFn(nEntries);
+  ary.reserve(nEntries);
+
   // Now loop until we get the desired number of entries from the stream
   for (size_t i = 0; i < nEntries; i++)
-    t_serializer.deserialize(*this, enumerator(), 0);
+    ary.serializer.deserialize(*this, ary.allocate(), 0);
 }
 
 void IArchiveImpl::ReadString(std::function<void*(uint64_t)> getBufferFn, uint8_t charSize, uint64_t ncb) {
@@ -175,9 +171,7 @@ void IArchiveImpl::ReadString(std::function<void*(uint64_t)> getBufferFn, uint8_
   ReadByteArray(pBuf, nEntries * charSize);
 }
 
-void IArchiveImpl::ReadDictionary(const field_serializer& keyDesc, void* key,
-                                  const field_serializer& valueDesc, void* value,
-                                  std::function<void(const void* key, const void* value)> insertionFn)
+void IArchiveImpl::ReadDictionary(IDictionaryInserter&& dictionary)
 {
   // Read the number of entries first:
   uint32_t nEntries;
@@ -185,11 +179,10 @@ void IArchiveImpl::ReadDictionary(const field_serializer& keyDesc, void* key,
   
   // Now read in all values:
   while (nEntries--) {
-    keyDesc.deserialize(*this, key, 0);
-    valueDesc.deserialize(*this, value, 0);
-    insertionFn(key,value);
+    dictionary.key_serializer.deserialize(*this, dictionary.key(), 0);
+    void* value = dictionary.insert();
+    dictionary.value_serializer.deserialize(*this, value, 0);
   }
-
 }
 
 IArchive::ReleasedMemory IArchiveImpl::Release(ReleasedMemory(*pfnAlloc)(), const field_serializer& serializer, uint32_t objId) {

--- a/src/leapserial/OArchiveImpl.cpp
+++ b/src/leapserial/OArchiveImpl.cpp
@@ -158,41 +158,49 @@ void OArchiveImpl::WriteInteger(int64_t value, uint8_t) {
     WriteByteArray(&ncb, 1);
 }
 
-void OArchiveImpl::WriteArray(const field_serializer& desc, uint64_t n, std::function<const void*()> enumerator) {
-  WriteSize((uint32_t)n);
+void OArchiveImpl::WriteArray(const IArray& ary) {
+  uint32_t n = (uint32_t)ary.size();
+  WriteSize(n);
   
-  while (n--)
-    desc.serialize(*this, enumerator());
+  for (uint32_t i = 0; i < n; i++)
+    ary.serializer.serialize(*this, ary.get(i));
 }
 
-uint64_t OArchiveImpl::SizeArray(const field_serializer& desc, uint64_t n, std::function<const void*()> enumerator) const {
+uint64_t OArchiveImpl::SizeArray(const IArray& ary) const {
   uint64_t sz = sizeof(uint32_t);
-  while (n--)
-    sz += desc.size(*this, enumerator());
+  size_t n = ary.size();
+  for (size_t i = 0; i < n; i++)
+    sz += ary.serializer.size(*this, ary.get(i));
   return sz;
 }
 
-void OArchiveImpl::WriteDictionary(uint64_t n,
-  const field_serializer& keyDesc, std::function<const void*()> keyEnumerator,
-  const field_serializer& valueDesc, std::function<const void*()> valueEnumerator)
+void OArchiveImpl::WriteDictionary(IDictionaryReader&& dictionary)
 {
+  uint32_t n = dictionary.size();
   WriteSize((uint32_t)n);
   
-  while (n--){
-    keyDesc.serialize(*this, keyEnumerator());
-    valueDesc.serialize(*this, valueEnumerator());
+  while (dictionary.next()) {
+    dictionary.key_serializer.serialize(*this, dictionary.key());
+    dictionary.value_serializer.serialize(*this, dictionary.value());
+    if (!n--)
+      break;
   }
+  if (n)
+    throw std::runtime_error("Dictionary size function reported a count inconsistent with the number of entries enumerated");
 }
 
-uint64_t OArchiveImpl::SizeDictionary(uint64_t n,
-  const field_serializer& keyDesc, std::function<const void*()> keyEnumerator,
-  const field_serializer& valueDesc, std::function<const void*()> valueEnumerator) const
+uint64_t OArchiveImpl::SizeDictionary(IDictionaryReader&& dictionary) const
 {
   uint64_t retVal = sizeof(uint32_t);
-  while (n--) {
-    retVal += keyDesc.size(*this, keyEnumerator());
-    retVal += valueDesc.size(*this, valueEnumerator());
+  size_t n = dictionary.size();
+  while (dictionary.next()) {
+    retVal += dictionary.key_serializer.size(*this, dictionary.key());
+    retVal += dictionary.value_serializer.size(*this, dictionary.value());
+    if (!n--)
+      break;
   }
+  if (n)
+    throw std::runtime_error("Dictionary size function reported a count inconsistent with the number of entries enumerated");
   return retVal;
 }
 

--- a/src/leapserial/OArchiveImpl.cpp
+++ b/src/leapserial/OArchiveImpl.cpp
@@ -158,7 +158,7 @@ void OArchiveImpl::WriteInteger(int64_t value, uint8_t) {
     WriteByteArray(&ncb, 1);
 }
 
-void OArchiveImpl::WriteArray(const IArray& ary) {
+void OArchiveImpl::WriteArray(IArrayReader&& ary) {
   uint32_t n = (uint32_t)ary.size();
   WriteSize(n);
   
@@ -166,7 +166,7 @@ void OArchiveImpl::WriteArray(const IArray& ary) {
     ary.serializer.serialize(*this, ary.get(i));
 }
 
-uint64_t OArchiveImpl::SizeArray(const IArray& ary) const {
+uint64_t OArchiveImpl::SizeArray(IArrayReader&& ary) const {
   uint64_t sz = sizeof(uint32_t);
   size_t n = ary.size();
   for (size_t i = 0; i < n; i++)


### PR DESCRIPTION
This interface type reduces the complexity and expense associated with calling the dictionary and vector serialization operations.  As we add more output formatters, simplicity in this interface will become increasingly important.