### PR TITLE
Implement protobuf output formatter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     - _CXX: g++-4.8
     - CMAKE_URL=http://cmake.org/files/v3.1/cmake-3.1.0-Linux-i386.tar.gz
     - CMAKE_DIRNAME=cmake-3.1.0-Linux-i386
+    - CMAKE_EXTRA_FLAGS=-DLS_PROTOBUF_REQUIRED:BOOL=ON
     addons:
       apt:
         sources:
@@ -17,12 +18,16 @@ matrix:
           - gcc-4.8
           - g++-4.8
           - libc6-i386
+          - protobuf-compiler
+          - libprotobuf-dev
   - os: osx
     env:
     - _CC: clang
     - _CXX: clang++
     - CMAKE_URL=http://cmake.org/files/v3.1/cmake-3.1.0-Darwin64.tar.gz
     - CMAKE_DIRNAME=cmake-3.1.0-Darwin64/CMake.app/Contents
+    - CMAKE_EXTRA_FLAGS=-DLS_PROTOBUF_REQUIRED:BOOL=ON
+    - BREW_COMMAND="brew install protobuf"
 
 before_install:
   # Enforce whitespace guidelines
@@ -41,10 +46,11 @@ before_script:
   - $CXX --version
   - export CPATH=/usr/include/c++/4.8:/usr/include/x86_64-linux-gnu/c++/4.8/:$CPATH
   - export LD_LIBRARY_PATH=/usr/lib/gcc/x86_64-linux-gnu/4.8:$LD_LIBRARY_PATH
+  - ${BREW_COMMAND}
 
 script:
   # Build LeapSerial, run unit tests, and install
-  - $CMAKE_DIRNAME/bin/cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:PATH=~/leapserial/
+  - $CMAKE_DIRNAME/bin/cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:PATH=~/leapserial/ ${CMAKE_EXTRA_FLAGS}
   - make -j 4 || make
   - ctest --output-on-failure
   - make install > logfile || cat logfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ matrix:
     - _CXX: clang++
     - CMAKE_URL=http://cmake.org/files/v3.1/cmake-3.1.0-Darwin64.tar.gz
     - CMAKE_DIRNAME=cmake-3.1.0-Darwin64/CMake.app/Contents
-    - CMAKE_EXTRA_FLAGS=-DLS_PROTOBUF_REQUIRED:BOOL=ON
-    - BREW_COMMAND="brew install protobuf"
+    - CMAKE_EXTRA_FLAGS=
 
 before_install:
   # Enforce whitespace guidelines

--- a/LeapSerial/Archive.h
+++ b/LeapSerial/Archive.h
@@ -35,9 +35,6 @@ namespace leap {
       T& cur;
       T prior;
     };
-
-    template<typename T>
-    Pusher<T> MakePusher(T& cur) { return Pusher<T>{cur}; }
   }
 
   /// <summary>

--- a/LeapSerial/Archive.h
+++ b/LeapSerial/Archive.h
@@ -19,6 +19,25 @@ namespace leap {
 
   namespace internal {
     class AllocationBase;
+
+    // Utility type for maintaining stack-based state
+    template<typename T>
+    struct Pusher {
+      Pusher(Pusher&&) = delete;
+      Pusher(const Pusher&) = delete;
+
+      Pusher(T& cur) :
+        cur(cur),
+        prior(cur)
+      {}
+      ~Pusher(void) { cur = prior; }
+
+      T& cur;
+      T prior;
+    };
+
+    template<typename T>
+    Pusher<T> MakePusher(T& cur) { return Pusher<T>{cur}; }
   }
 
   /// <summary>

--- a/LeapSerial/ArchiveProtobuf.h
+++ b/LeapSerial/ArchiveProtobuf.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "Archive.h"
+#include "IArchiveProtobuf.h"
+#include "OArchiveProtobuf.h"

--- a/LeapSerial/IArchiveProtobuf.h
+++ b/LeapSerial/IArchiveProtobuf.h
@@ -1,0 +1,39 @@
+#pragma once
+#include "Archive.h"
+
+namespace leap {
+  class IArchiveProtobuf :
+    public IArchiveRegistry
+  {
+  public:
+    IArchiveProtobuf(IInputStream& is);
+
+    void ReadObject(const field_serializer& sz, void* pObj, internal::AllocationBase* pOwner) override;
+    ReleasedMemory ReadObjectReferenceResponsible(ReleasedMemory(*pfnAlloc)(), const field_serializer& sz, bool isUnique) override;
+
+    void Skip(uint64_t ncb) override;
+    uint64_t Count(void) const override { return 0; }
+
+    void ReadDescriptor(const descriptor& descriptor, void* pObj, uint64_t ncb) override;
+    void ReadByteArray(void* pBuf, uint64_t ncb) override;
+    void ReadString(std::function<void*(uint64_t)> getBufferFn, uint8_t charSize, uint64_t ncb) override;
+    bool ReadBool(void) override;
+    uint64_t ReadInteger(uint8_t) override;
+    void ReadFloat(float& value) override { is.Read(&value, sizeof(value)); }
+    void ReadFloat(double& value) override { is.Read(&value, sizeof(value)); }
+    void ReadArray(IArrayAppender&& ary) override;
+    void ReadDictionary(IDictionaryInserter&& rdr) override;
+
+    void* ReadObjectReference(const create_delete& cd, const field_serializer& desc) override;
+
+  private:
+    void ReadSingle(const descriptor& descriptor, void* pObj);
+
+    // Descriptor of current object being read, if any exist:
+    const descriptor* m_pCurDesc = nullptr;
+
+    // Stream traits:
+    uint64_t m_count = 0;
+    IInputStream& is;
+  };
+}

--- a/LeapSerial/OArchiveProtobuf.h
+++ b/LeapSerial/OArchiveProtobuf.h
@@ -1,0 +1,55 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "Archive.h"
+#include <memory>
+
+namespace leap {
+  struct field_descriptor;
+
+  class OArchiveProtobuf :
+    public OArchiveRegistry
+  {
+  public:
+    OArchiveProtobuf(IOutputStream& os);
+
+    // OArchiveRegistry overrides
+    void WriteByteArray(const void* pBuf, uint64_t ncb, bool writeSize = false) override;
+    void WriteString(const void* pBuf, uint64_t charCount, uint8_t charSize) override;
+    void WriteBool(bool value) override { WriteInteger(value, 1); }
+    void WriteInteger(int64_t value, uint8_t) override;
+    void WriteFloat(float value) override;
+    void WriteFloat(double value) override;
+    void WriteObjectReference(const field_serializer& serializer, const void* pObj) override;
+    void WriteObject(const field_serializer& serializer, const void* pObj) override;
+
+    /// <summary>
+    /// Writes a top-level context-free descriptor
+    /// </summary>
+    /// <remarks>
+    /// A context-free descriptor has no identifier word or length field; this must be written by
+    /// the outer scope if it is desired.
+    /// </remarks>
+    void WriteDescriptor(const descriptor& descriptor, const void* pObj) override;
+
+    void WriteArray(IArrayReader&& ary) override;
+    void WriteDictionary(IDictionaryReader&& dictionary) override;
+
+    //Size query functions.  Note that these do not return the total size of the object,
+    //but rather the size they take up in a table (sizeof(uint32_t) for objects stored by reference).
+    uint64_t SizeInteger(int64_t value, uint8_t) const override;
+    uint64_t SizeFloat(float value) const override { return 4; }
+    uint64_t SizeFloat(double value) const override { return 8; }
+    uint64_t SizeBool(bool value) const override { return 1; }
+    uint64_t SizeString(const void* pBuf, uint64_t ncb, uint8_t charSize) const override;
+    uint64_t SizeObjectReference(const field_serializer& serializer, const void* pObj) const override;
+    uint64_t SizeDescriptor(const descriptor& descriptor, const void* pObj) const override;
+    uint64_t SizeArray(IArrayReader&& ary) const override;
+    uint64_t SizeDictionary(IDictionaryReader&& dictionary) const override;
+
+  private:
+    IOutputStream& os;
+
+    // Stateful:  Stores the identifier of the object presently being serialized
+    mutable const std::pair<const uint64_t, field_descriptor>* curDescEntry = nullptr;
+  };
+}

--- a/src/leapserial/CMakeLists.txt
+++ b/src/leapserial/CMakeLists.txt
@@ -7,6 +7,9 @@ set(LeapSerial_SRCS
   ArchiveFlatbuffer.cpp
   ArchiveJSON.h
   ArchiveJSON.cpp
+  ArchiveProtobuf.h
+  IArchiveProtobuf.cpp
+  OArchiveProtobuf.cpp
   base.h
   Descriptor.h
   Descriptor.cpp
@@ -21,6 +24,8 @@ set(LeapSerial_SRCS
   OArchiveImpl.h
   OArchiveImpl.cpp
   optional.h
+  ProtobufUtil.cpp
+  ProtobufUtil.hpp
   LeapSerial.h
   serial_traits.h
   Utility.hpp

--- a/src/leapserial/IArchiveImpl.cpp
+++ b/src/leapserial/IArchiveImpl.cpp
@@ -93,9 +93,9 @@ void IArchiveImpl::ReadDescriptor(const descriptor& descriptor, void* pObj, uint
   uint64_t countLimit = Count() + ncb;
   for (const auto& field_descriptor : descriptor.field_descriptors)
     field_descriptor.serializer.deserialize(
-    *this,
-    static_cast<char*>(pObj)+field_descriptor.offset,
-    0
+      *this,
+      static_cast<char*>(pObj)+field_descriptor.offset,
+      0
     );
 
   if (!ncb)

--- a/src/leapserial/IArchiveProtobuf.cpp
+++ b/src/leapserial/IArchiveProtobuf.cpp
@@ -50,6 +50,8 @@ void IArchiveProtobuf::ReadSingle(const descriptor& descriptor, void* pObj) {
     case protobuf::WireType::StartGroup:
     case protobuf::WireType::EndGroup:
       throw std::runtime_error("Unexpected protobuf wire type");
+    case protobuf::WireType::ObjReference:
+      throw std::runtime_error("Cannot serialize object references");
     }
   else
     // Straight handoff to deserialize

--- a/src/leapserial/IArchiveProtobuf.cpp
+++ b/src/leapserial/IArchiveProtobuf.cpp
@@ -47,6 +47,9 @@ void IArchiveProtobuf::ReadSingle(const descriptor& descriptor, void* pObj) {
     case protobuf::WireType::QuadWord:
       Skip(8);
       break;
+    case protobuf::WireType::StartGroup:
+    case protobuf::WireType::EndGroup:
+      throw std::runtime_error("Unexpected protobuf wire type");
     }
   else
     // Straight handoff to deserialize

--- a/src/leapserial/IArchiveProtobuf.cpp
+++ b/src/leapserial/IArchiveProtobuf.cpp
@@ -66,7 +66,7 @@ void IArchiveProtobuf::ReadDescriptor(const descriptor& descriptor, void* pObj, 
     // will be.  So, we read out the length here in this case.
     ncb = ReadInteger(8);
 
-  auto r = leap::internal::MakePusher(m_pCurDesc);
+  leap::internal::Pusher<decltype(m_pCurDesc)> r(m_pCurDesc);
   m_pCurDesc = &descriptor;
 
   if(ncb)
@@ -113,8 +113,8 @@ void IArchiveProtobuf::ReadArray(IArrayAppender&& ary) {
 void IArchiveProtobuf::ReadDictionary(IDictionaryInserter&& dictionary)
 {
   // Read out length field first
-  size_t ncb = ReadInteger(8);
-  size_t maxCount = m_count + ncb;
+  uint64_t ncb = ReadInteger(8);
+  uint64_t maxCount = m_count + ncb;
   while (m_count < maxCount) {
     // Key first, then value
     dictionary.key_serializer.deserialize(*this, dictionary.key(), maxCount - m_count);

--- a/src/leapserial/IArchiveProtobuf.cpp
+++ b/src/leapserial/IArchiveProtobuf.cpp
@@ -1,0 +1,129 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "IArchiveProtobuf.h"
+#include "Descriptor.h"
+#include "field_serializer.h"
+#include "ProtobufUtil.hpp"
+#include "Utility.hpp"
+#include <iostream>
+
+using namespace leap;
+
+IArchiveProtobuf::IArchiveProtobuf(IInputStream& is) :
+  is(is)
+{}
+
+void IArchiveProtobuf::ReadObject(const field_serializer& sz, void* pObj, internal::AllocationBase* pOwner) {
+  sz.deserialize(*this, pObj, 0);
+}
+
+IArchive::ReleasedMemory IArchiveProtobuf::ReadObjectReferenceResponsible(ReleasedMemory(*pfnAlloc)(), const field_serializer& sz, bool isUnique) {
+  return{nullptr, nullptr};
+}
+
+void IArchiveProtobuf::Skip(uint64_t ncb) {
+  is.Skip(ncb);
+  m_count += ncb;
+}
+
+void IArchiveProtobuf::ReadSingle(const descriptor& descriptor, void* pObj) {
+  uint64_t v = ReadInteger(0);
+  protobuf::WireType type = static_cast<protobuf::WireType>(v & 7);
+  uint64_t ident = v >> 3;
+
+  auto q = descriptor.identified_descriptors.find(ident);
+  if (q == descriptor.identified_descriptors.end())
+    // Skip behavior
+    switch (type) {
+    case protobuf::WireType::Varint:
+      ReadInteger(0);
+      break;
+    case protobuf::WireType::LenDelimit:
+      Skip(ReadInteger(0));
+      break;
+    case protobuf::WireType::DoubleWord:
+      Skip(4);
+      break;
+    case protobuf::WireType::QuadWord:
+      Skip(8);
+      break;
+    }
+  else
+    // Straight handoff to deserialize
+    q->second.serializer.deserialize(
+      *this,
+      reinterpret_cast<uint8_t*>(pObj) + q->second.offset,
+      0
+    );
+}
+
+void IArchiveProtobuf::ReadDescriptor(const descriptor& descriptor, void* pObj, uint64_t ncb) {
+  if (!descriptor.field_descriptors.empty())
+    throw leap::protobuf::serialization_error{ descriptor };
+
+  if (m_pCurDesc)
+    // We are not the root type.  The root type is not length-delimited, but all embedded messages
+    // will be.  So, we read out the length here in this case.
+    ncb = ReadInteger(8);
+
+  auto r = leap::internal::MakePusher(m_pCurDesc);
+  m_pCurDesc = &descriptor;
+
+  if(ncb)
+  {
+    uint64_t maxCount = m_count + ncb;
+    while (m_count < maxCount)
+      ReadSingle(descriptor, pObj);
+  }
+  else
+    while (!is.IsEof())
+      ReadSingle(descriptor, pObj);
+}
+
+void IArchiveProtobuf::ReadByteArray(void* pBuf, uint64_t ncb) {
+}
+
+void IArchiveProtobuf::ReadString(std::function<void*(uint64_t)> getBufferFn, uint8_t charSize, uint64_t ncb) {
+  uint64_t n = ReadInteger(0);
+  void* pBuf = getBufferFn(n);
+  is.Read(pBuf, n);
+  m_count += n;
+}
+
+bool IArchiveProtobuf::ReadBool(void) {
+  return !!ReadInteger(0);
+}
+
+uint64_t IArchiveProtobuf::ReadInteger(uint8_t) {
+  size_t ncb = 0;
+  uint8_t buf[10];
+  do is.Read(buf, 1);
+  while (buf[ncb++] & 0x80);
+  m_count += ncb;
+  return leap::FromBase128(buf, ncb);
+}
+
+void IArchiveProtobuf::ReadArray(IArrayAppender&& ary) {
+  // Protobuf array deserialization is funny, it's just a bunch of single entries repeated
+  // over and over again.
+  void* pEntry = ary.allocate();
+  ary.serializer.deserialize(*this, pEntry, 0);
+}
+
+void IArchiveProtobuf::ReadDictionary(IDictionaryInserter&& dictionary)
+{
+  // Read out length field first
+  size_t ncb = ReadInteger(8);
+  size_t maxCount = m_count + ncb;
+  while (m_count < maxCount) {
+    // Key first, then value
+    dictionary.key_serializer.deserialize(*this, dictionary.key(), maxCount - m_count);
+    if (maxCount <= m_count)
+      throw std::runtime_error("Stream torn while reading a dictionary");
+    dictionary.value_serializer.deserialize(*this, dictionary.insert(), maxCount - m_count);
+  }
+}
+
+void* IArchiveProtobuf::ReadObjectReference(const create_delete& cd, const field_serializer& desc) {
+  return nullptr;
+}

--- a/src/leapserial/OArchiveProtobuf.cpp
+++ b/src/leapserial/OArchiveProtobuf.cpp
@@ -64,7 +64,7 @@ void OArchiveProtobuf::WriteDescriptor(const descriptor& descriptor, const void*
     throw leap::protobuf::serialization_error{ descriptor };
 
   // Now we write out the identified fields in order.
-  auto pshr = leap::internal::MakePusher(curDescEntry);
+  leap::internal::Pusher<decltype(curDescEntry)> p(curDescEntry);
   for (const auto& identified_descriptor : descriptor.identified_descriptors) {
     const auto& member_field = identified_descriptor.second;
     const void* pMember = reinterpret_cast<const uint8_t*>(pObj) + member_field.offset;
@@ -172,7 +172,7 @@ uint64_t OArchiveProtobuf::SizeObjectReference(const field_serializer& serialize
 }
 
 uint64_t OArchiveProtobuf::SizeDescriptor(const descriptor& descriptor, const void* pObj) const {
-  auto restoreIdent = leap::internal::MakePusher(curDescEntry);
+  leap::internal::Pusher<decltype(curDescEntry)> p(curDescEntry);
   
   // Context-free.  We just write out the identified fields in order.
   uint64_t retVal = 0;

--- a/src/leapserial/OArchiveProtobuf.cpp
+++ b/src/leapserial/OArchiveProtobuf.cpp
@@ -98,6 +98,8 @@ void OArchiveProtobuf::WriteDescriptor(const descriptor& descriptor, const void*
       // Map type is implemented basically the same way as array, except entries are pairs
       curDescEntry = &identified_descriptor;
       break;
+    case serial_atom::ignored:
+      throw std::runtime_error("Invalid serialization atom type returned");
     }
 
     // Now we write the payload proper
@@ -199,6 +201,8 @@ uint64_t OArchiveProtobuf::SizeDescriptor(const descriptor& descriptor, const vo
     case serial_atom::map:
       curDescEntry = &identified_descriptor;
       break;
+    case serial_atom::ignored:
+      throw std::runtime_error("Invalid serialization atom type returned");
     }
     
     uint64_t ncb = member_field.serializer.size(
@@ -213,6 +217,9 @@ uint64_t OArchiveProtobuf::SizeDescriptor(const descriptor& descriptor, const vo
       // These are all counted fields.  GetDescriptor is responsible for writing out the length
       // in advance of these calls, and so we must account for this length here.
       retVal += leap::SizeBase128(ncb);
+      break;
+    default:
+      // Do nothing
       break;
     }
     retVal += ncb;

--- a/src/leapserial/OArchiveProtobuf.cpp
+++ b/src/leapserial/OArchiveProtobuf.cpp
@@ -1,0 +1,244 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "OArchiveProtobuf.h"
+#include "Descriptor.h"
+#include "field_serializer.h"
+#include "ProtobufUtil.hpp"
+#include "Utility.hpp"
+#include <iostream>
+#include <sstream>
+
+using namespace leap;
+
+OArchiveProtobuf::OArchiveProtobuf(IOutputStream& os):
+  os(os)
+{}
+
+void OArchiveProtobuf::WriteByteArray(const void* pBuf, uint64_t ncb, bool writeSize) {
+
+}
+
+void OArchiveProtobuf::WriteString(const void* pBuf, uint64_t charCount, uint8_t charSize) {
+  os.Write(pBuf, charCount);
+}
+
+void OArchiveProtobuf::WriteInteger(int64_t value, uint8_t) {
+  size_t ncb = 0;
+  auto varint = leap::ToBase128(value, ncb);
+
+  if (ncb)
+    // Write out our composed varint
+    os.Write(varint.data(), ncb);
+  else
+    // Just write one byte of zero
+    os.Write(&ncb, 1);
+}
+
+void OArchiveProtobuf::WriteFloat(float value) {
+  os.Write(&value, sizeof(value));
+}
+
+void OArchiveProtobuf::WriteFloat(double value) {
+  os.Write(&value, sizeof(value));
+}
+
+void OArchiveProtobuf::WriteObjectReference(const field_serializer& serializer, const void* pObj) {
+
+}
+
+void OArchiveProtobuf::WriteObject(const field_serializer& serializer, const void* pObj) {
+  // Root object, no identifier.  We just pass control to the serializer.
+  try {
+    serializer.serialize(*this, pObj);
+  }
+  catch (leap::protobuf::serialization_error& ex) {
+    std::ostringstream ss;
+    ss << "While processing the root object:" << std::endl
+       << ex.what();
+    throw leap::protobuf::serialization_error{ ss.str() };
+  }
+}
+
+void OArchiveProtobuf::WriteDescriptor(const descriptor& descriptor, const void* pObj) {
+  if (!descriptor.field_descriptors.empty())
+    throw leap::protobuf::serialization_error{ descriptor };
+
+  // Now we write out the identified fields in order.
+  auto pshr = leap::internal::MakePusher(curDescEntry);
+  for (const auto& identified_descriptor : descriptor.identified_descriptors) {
+    const auto& member_field = identified_descriptor.second;
+    const void* pMember = reinterpret_cast<const uint8_t*>(pObj) + member_field.offset;
+
+    // Header with the identifier and wire type.  For some serializers, we are responsible for writing out
+    // the wire type; for other serializers, the wire type must be written out by the serializer itself.
+    switch(member_field.serializer.type()) {
+    case serial_atom::boolean:
+    case serial_atom::i8:
+    case serial_atom::i16:
+    case serial_atom::i32:
+    case serial_atom::i64:
+    case serial_atom::f32:
+    case serial_atom::f64:
+      // These types are all context-free, we are responsible for writing the identifier here, and the
+      // type itself will handle things from there.
+      WriteInteger((member_field.identifier << 3) | (size_t)protobuf::ToWireType(member_field.serializer.type()), 8);
+      break;
+    case serial_atom::string:
+    case serial_atom::descriptor:
+    case serial_atom::finalized_descriptor:
+      // Counted strings, we need to write out the header and then the length verbatim
+      WriteInteger((member_field.identifier << 3) | (size_t)protobuf::WireType::LenDelimit, 8);
+      WriteInteger(member_field.serializer.size(*this, pMember), 8);
+      break;
+    case serial_atom::reference:
+      break;
+    case serial_atom::array:
+      // Array type is very inefficient.  It stamps out the field name and type for each entry in the array.
+    case serial_atom::map:
+      // Map type is implemented basically the same way as array, except entries are pairs
+      curDescEntry = &identified_descriptor;
+      break;
+    }
+
+    // Now we write the payload proper
+    member_field.serializer.serialize(*this, pMember);
+  }
+}
+
+void OArchiveProtobuf::WriteArray(IArrayReader&& ary) {
+  protobuf::WireType wireType = protobuf::ToWireType(ary.serializer.type());
+  uint64_t key = (curDescEntry->first << 3) | (size_t)wireType;
+  size_t n = ary.size();
+  for (size_t i = 0; i < n; i++) {
+    WriteInteger(key, 8);
+
+    const void* pObj = ary.get(i);
+    if (wireType == protobuf::WireType::LenDelimit)
+      WriteInteger(ary.serializer.size(*this, pObj), 8);
+    ary.serializer.serialize(*this, pObj);
+  }
+}
+
+void OArchiveProtobuf::WriteDictionary(IDictionaryReader&& dictionary) {
+  // We are responsible for writing out our header constraints just as OArchiveProtobuf is, except we know that
+  // the wire type is length-delimited
+  uint64_t header = (curDescEntry->first << 3) | (size_t)protobuf::WireType::LenDelimit;
+
+  // Key always has an ID of 1, as per spec
+  protobuf::WireType keyType = protobuf::ToWireType(dictionary.key_serializer.type());
+  uint64_t keyID = (1 << 3) | static_cast<uint32_t>(keyType);
+
+  // Value always has an ID of 2, as per spec
+  protobuf::WireType valueType = protobuf::ToWireType(dictionary.value_serializer.type());
+  uint64_t valueID = (2 << 3) | static_cast<uint32_t>(valueType);
+
+  // Invariant computation
+  uint64_t keyvalSize = leap::SizeBase128(keyID) + leap::SizeBase128(valueID);
+
+  while (dictionary.next()) {
+    uint64_t keySize = dictionary.key_serializer.size(*this, dictionary.key());
+    uint64_t valSize = dictionary.value_serializer.size(*this, dictionary.value());
+
+    // Need the object header, which will be a LenDelimit struct, and the size in advance
+    WriteInteger(header, 8);
+    WriteInteger(
+      keyvalSize +
+      keySize + (keyType == protobuf::WireType::LenDelimit ? leap::SizeBase128(keySize) : 0) +
+      valSize + (valueType == protobuf::WireType::LenDelimit ? leap::SizeBase128(valSize) : 0),
+      8
+    );
+    
+    WriteInteger(keyID, 8);
+    if (keyType == protobuf::WireType::LenDelimit)
+      WriteInteger(dictionary.key_serializer.size(*this, dictionary.key()), 8);
+    dictionary.key_serializer.serialize(*this, dictionary.key());
+    WriteInteger(valueID, 8);
+    if (valueType == protobuf::WireType::LenDelimit)
+      WriteInteger(dictionary.value_serializer.size(*this, dictionary.value()), 8);
+    dictionary.value_serializer.serialize(*this, dictionary.value());
+  }
+}
+
+uint64_t OArchiveProtobuf::SizeInteger(int64_t value, uint8_t) const {
+  return leap::SizeBase128(value);
+}
+
+uint64_t OArchiveProtobuf::SizeString(const void* pBuf, uint64_t ncb, uint8_t charSize) const {
+  return ncb;
+}
+
+uint64_t OArchiveProtobuf::SizeObjectReference(const field_serializer& serializer, const void* pObj) const {
+  return 0;
+}
+
+uint64_t OArchiveProtobuf::SizeDescriptor(const descriptor& descriptor, const void* pObj) const {
+  auto restoreIdent = leap::internal::MakePusher(curDescEntry);
+  
+  // Context-free.  We just write out the identified fields in order.
+  uint64_t retVal = 0;
+  for (const auto& identified_descriptor : descriptor.identified_descriptors) {
+    const auto& member_field = identified_descriptor.second;
+
+    switch(member_field.serializer.type()) {
+    case serial_atom::boolean:
+    case serial_atom::i8:
+    case serial_atom::i16:
+    case serial_atom::i32:
+    case serial_atom::i64:
+    case serial_atom::f32:
+    case serial_atom::f64:
+    case serial_atom::string:
+    case serial_atom::descriptor:
+    case serial_atom::finalized_descriptor:
+      // Only need to record the header size:
+      retVal += leap::SizeBase128((member_field.identifier << 3) | (size_t)protobuf::ToWireType(member_field.serializer.type()));
+      break;
+    case serial_atom::reference:
+      break;
+    case serial_atom::array:
+    case serial_atom::map:
+      curDescEntry = &identified_descriptor;
+      break;
+    }
+    
+    uint64_t ncb = member_field.serializer.size(
+      *this,
+      reinterpret_cast<const uint8_t*>(pObj) + member_field.offset
+    );
+
+    switch (member_field.serializer.type()) {
+    case serial_atom::string:
+    case serial_atom::descriptor:
+    case serial_atom::finalized_descriptor:
+      // These are all counted fields.  GetDescriptor is responsible for writing out the length
+      // in advance of these calls, and so we must account for this length here.
+      retVal += leap::SizeBase128(ncb);
+      break;
+    }
+    retVal += ncb;
+  }
+  // Also need to include the number of bytes that will be needed to represent the size itself
+  return retVal;
+}
+
+uint64_t OArchiveProtobuf::SizeArray(IArrayReader&& ary) const {
+  uint64_t keySize = leap::SizeBase128(
+    (curDescEntry->first << 3) | (size_t)protobuf::ToWireType(ary.serializer.type())
+  );
+  size_t n = ary.size();
+  uint64_t retVal = keySize * n;
+  while (n--)
+    retVal += ary.serializer.size(*this, ary.get(n));
+  return retVal;
+}
+
+uint64_t OArchiveProtobuf::SizeDictionary(IDictionaryReader&& dictionary) const {
+  uint64_t keySize = leap::SizeBase128(
+    (curDescEntry->first << 3) | (size_t)protobuf::ToWireType(dictionary.key_serializer.type())
+  );
+  uint64_t retVal = 0;
+  size_t n = dictionary.size();
+  while (dictionary.next())
+    retVal += keySize + dictionary.value_serializer.size(*this, dictionary.value());
+  return retVal;
+}

--- a/src/leapserial/ProtobufUtil.cpp
+++ b/src/leapserial/ProtobufUtil.cpp
@@ -31,6 +31,8 @@ protobuf::WireType leap::protobuf::ToWireType(serial_atom atom) {
     return protobuf::WireType::LenDelimit;
   case serial_atom::finalized_descriptor:
     break;
+  case serial_atom::ignored:
+    throw std::invalid_argument("serial_atom::ignored is a utility type and should not be used in ordinary operations");
   }
   throw std::invalid_argument("Attempted to find a wire type for an unrecognized serial atom type");
 }

--- a/src/leapserial/ProtobufUtil.cpp
+++ b/src/leapserial/ProtobufUtil.cpp
@@ -44,6 +44,10 @@ static std::string FormatError(const descriptor& descriptor) {
   return ss.str();
 }
 
+protobuf::serialization_error::serialization_error(std::string what) :
+  std::runtime_error(std::move(what))
+{}
+
 protobuf::serialization_error::serialization_error(const descriptor& descriptor) :
   std::runtime_error(FormatError(descriptor))
 {}

--- a/src/leapserial/ProtobufUtil.cpp
+++ b/src/leapserial/ProtobufUtil.cpp
@@ -3,6 +3,7 @@
 #include "ProtobufUtil.hpp"
 #include "Archive.h"
 #include "Descriptor.h"
+#include <iomanip>
 #include <sstream>
 
 using namespace leap;

--- a/src/leapserial/ProtobufUtil.cpp
+++ b/src/leapserial/ProtobufUtil.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "ProtobufUtil.hpp"
+#include "Archive.h"
+#include "Descriptor.h"
+#include <sstream>
+
+using namespace leap;
+
+protobuf::WireType leap::protobuf::ToWireType(serial_atom atom) {
+  switch (atom) {
+  case serial_atom::boolean:
+  case serial_atom::i8:
+  case serial_atom::i16:
+  case serial_atom::i32:
+  case serial_atom::i64:
+    return protobuf::WireType::Varint;
+  case serial_atom::f32:
+    return protobuf::WireType::DoubleWord;
+  case serial_atom::f64:
+    return protobuf::WireType::QuadWord;
+  case serial_atom::reference:
+  case serial_atom::array:
+    return protobuf::WireType::LenDelimit;
+  case serial_atom::string:
+    return protobuf::WireType::LenDelimit;
+  case serial_atom::map:
+    break;
+  case serial_atom::descriptor:
+    return protobuf::WireType::LenDelimit;
+  case serial_atom::finalized_descriptor:
+    break;
+  }
+  throw std::invalid_argument("Attempted to find a wire type for an unrecognized serial atom type");
+}
+
+static std::string FormatError(const descriptor& descriptor) {
+  std::stringstream ss;
+  ss << "The OArchiveProtobuf requires that all entries have identifiers" << std::endl
+     << "Fields at the following offsets do not have identifiers:" << std::endl;
+  for (const auto& field_descriptor : descriptor.field_descriptors)
+    ss << "[ " << std::left << std::setw(8) << ToString(field_descriptor.serializer.type()) << " ] @+" << field_descriptor.offset << std::endl;
+  return ss.str();
+}
+
+protobuf::serialization_error::serialization_error(const descriptor& descriptor) :
+  std::runtime_error(FormatError(descriptor))
+{}

--- a/src/leapserial/ProtobufUtil.hpp
+++ b/src/leapserial/ProtobufUtil.hpp
@@ -25,9 +25,7 @@ namespace leap {
     struct serialization_error :
       public std::runtime_error
     {
-      serialization_error(std::string what) :
-        std::runtime_error(std::move(what))
-      {}
+      serialization_error(std::string what);
       serialization_error(const descriptor& descriptor);
     };
   }

--- a/src/leapserial/ProtobufUtil.hpp
+++ b/src/leapserial/ProtobufUtil.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include <memory>
+#include <stdexcept>
+
+namespace leap {
+  struct descriptor;
+  enum class serial_atom;
+
+  namespace protobuf {
+    enum class WireType {
+      Varint = 0,
+      QuadWord = 1,
+      LenDelimit = 2,
+      StartGroup = 3,  // Deprecated
+      EndGroup = 4,    // Deprecated
+      DoubleWord = 5,
+
+      // Nonstandard extension
+      ObjReference = 7
+    };
+
+    protobuf::WireType ToWireType(serial_atom atom);
+
+    struct serialization_error :
+      public std::runtime_error
+    {
+      serialization_error(std::string what) :
+        std::runtime_error(std::move(what))
+      {}
+      serialization_error(const descriptor& descriptor);
+    };
+  }
+}

--- a/src/leapserial/test/ArchiveProtobufTest.cpp
+++ b/src/leapserial/test/ArchiveProtobufTest.cpp
@@ -1,0 +1,154 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "LeapSerial.h"
+#include "IArchiveProtobuf.h"
+#include "OArchiveProtobuf.h"
+#include <gtest/gtest.h>
+#include <sstream>
+
+// This is required on Windows due to the way protobuf uses std::copy
+#define _SCL_SECURE_NO_WARNINGS
+#include "TestProtobuf.pb.h"
+#undef _SCL_SECURE_NO_WARNINGS
+
+namespace {
+  class PhoneNumber {
+  public:
+    enum PhoneType {
+      MOBILE,
+      HOME,
+      WORK
+    };
+
+    std::string number;
+    PhoneType type;
+
+    bool operator==(const PhoneNumber& rhs) const {
+      return number == rhs.number && type == rhs.type;
+    }
+
+    static leap::descriptor GetDescriptor(void) {
+      return{
+        { 1, &PhoneNumber::number },
+        { 2, &PhoneNumber::type }
+      };
+    }
+  };
+
+  class Pet {
+  public:
+    std::string name;
+
+    enum class Species {
+      DOG = 0,
+      CAT = 1
+    };
+    Species species;
+
+    static leap::descriptor GetDescriptor(void) {
+      return {
+        { 1, &Pet::name },
+        { 2, &Pet::species }
+      };
+    }
+  };
+
+  class Person {
+  public:
+    std::string name;
+    int id;
+    std::string email;
+    std::vector<PhoneNumber> phone;
+    std::map<std::string, Pet> pets;
+
+    bool operator==(const Person& rhs) const {
+      return
+        name == rhs.name &&
+        id == rhs.id &&
+        email == rhs.email &&
+        phone == rhs.phone;
+    }
+
+    static leap::descriptor GetDescriptor(void) {
+      return {
+        { 1, &Person::name },
+        { 2, &Person::id },
+        { 3, &Person::email },
+        { 4, &Person::phone },
+        { 5, &Person::pets }
+      };
+    }
+  };
+}
+
+static std::string ToProtobuf(const Person& in) {
+  // Write the protobuf version first:
+  leap::test::Person person;
+  person.set_name(in.name);
+  person.set_id(in.id);
+  person.set_email(in.email);
+
+  for (const auto& pn : in.phone) {
+    auto* phoneNumber = person.add_phone();
+    phoneNumber->set_number(pn.number);
+    phoneNumber->set_type(static_cast<leap::test::Person_PhoneType>(pn.type));
+  }
+  for (const auto& entry : in.pets) {
+    leap::test::PetFieldEntry* petEntry = person.add_pet();
+    petEntry->set_key(entry.first);
+
+    leap::test::Pet* pet = petEntry->mutable_value();
+    pet->set_name(entry.second.name);
+    pet->set_species((leap::test::Pet_Species)entry.second.species);
+  }
+  return person.SerializeAsString();
+}
+
+static Person MakeDefaultPerson(void) {
+  Person person;
+  person.name = "John";
+  person.id = 100;
+  person.email = "john@johnshouse.com";
+  person.phone.resize(1);
+  person.phone[0].number = "210-555-9294";
+  person.phone[0].type = PhoneNumber::HOME;
+  Pet& snake = person.pets["snake"];
+  snake.name = "Snake";
+  snake.species = Pet::Species::DOG;
+  return person;
+}
+
+TEST(ArchiveProtobufTest, SerializationEquivalence) {
+  // Create reference string that we will serialize to protobuf
+  const Person defaultPerson = MakeDefaultPerson();
+  std::string reference = ToProtobuf(defaultPerson);
+
+  // Now use LeapSerial to serialize the selfsame object:
+  std::stringstream ss;
+
+  leap::Serialize<leap::OArchiveProtobuf>(leap::OutputStreamAdapter(ss), defaultPerson);
+  std::string val = ss.str();
+
+  ASSERT_EQ(val, reference) << "Failed to serialize to a reference protobuf buffer";
+}
+
+TEST(ArchiveProtobufTest, LeapSerialToProtobuf) {
+  const Person defaultPerson = MakeDefaultPerson();
+
+  std::stringstream ss;
+  leap::Serialize<leap::OArchiveProtobuf>(leap::OutputStreamAdapter(ss), defaultPerson);
+  std::string val = ss.str();
+
+  leap::test::Person person;
+  ASSERT_TRUE(person.ParseFromString(val)) << "Failed to deserialize a LeapSerial-formatted reference message";
+}
+
+TEST(ArchiveProtobufTest, ProtobufToLeapSerial) {
+  const Person defaultPerson = MakeDefaultPerson();
+  std::string s = ToProtobuf(defaultPerson);
+  std::stringstream ss(s);
+
+  Person person;
+  leap::Deserialize<leap::IArchiveProtobuf>(leap::InputStreamAdapter(ss), person);
+  ASSERT_EQ(person, defaultPerson);
+}

--- a/src/leapserial/test/ArchiveProtobufTest.cpp
+++ b/src/leapserial/test/ArchiveProtobufTest.cpp
@@ -118,20 +118,6 @@ static Person MakeDefaultPerson(void) {
   return person;
 }
 
-TEST(ArchiveProtobufTest, SerializationEquivalence) {
-  // Create reference string that we will serialize to protobuf
-  const Person defaultPerson = MakeDefaultPerson();
-  std::string reference = ToProtobuf(defaultPerson);
-
-  // Now use LeapSerial to serialize the selfsame object:
-  std::stringstream ss;
-
-  leap::Serialize<leap::OArchiveProtobuf>(leap::OutputStreamAdapter(ss), defaultPerson);
-  std::string val = ss.str();
-
-  ASSERT_EQ(val, reference) << "Failed to serialize to a reference protobuf buffer";
-}
-
 TEST(ArchiveProtobufTest, LeapSerialToProtobuf) {
   const Person defaultPerson = MakeDefaultPerson();
 

--- a/src/leapserial/test/CMakeLists.txt
+++ b/src/leapserial/test/CMakeLists.txt
@@ -32,6 +32,31 @@ add_conditional_sources(
   TestObject_generated.h
 )
 
+find_package(Protobuf 2.5.0 QUIET)
+if(Protobuf_FOUND)
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.pb.cc ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.pb.h
+    COMMAND Protobuf::protoc -I ${CMAKE_CURRENT_SOURCE_DIR} --cpp_out=${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.proto
+    MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.proto
+    COMMENT "Generating TestProtobuf.pb.cc and TestProtobuf.pb.h"
+    VERBATIM
+  )
+else()
+  file(WRITE TestProtobuf.pb.h)
+  file(WRITE TestProtobuf.pb.cc)
+endif()
+
+add_conditional_sources(
+  LeapSerialTest_SRCS
+  "Protobuf_FOUND"
+  GROUP_NAME "Protobuf"
+  FILES
+  ArchiveProtobufTest.cpp
+  TestProtobuf.proto
+  TestProtobuf.pb.h
+  TestProtobuf.pb.cc
+)
+
 find_package(Threads)
 add_executable(LeapSerialTest ${LeapSerialTest_SRCS} ../../gtest-all-guard.cpp)
 target_link_libraries(LeapSerialTest LeapSerial ${CMAKE_THREAD_LIBS_INIT})
@@ -41,7 +66,6 @@ if(${FlatBuffers_FOUND})
   target_link_libraries(LeapSerialTest FlatBuffers::FlatBuffers)
 endif()
 
-find_package(Protobuf 2.5.0 QUIET)
 if(${Protobuf_FOUND})
   target_link_libraries(LeapSerialTest Protobuf::Protobuf)
 endif()

--- a/src/leapserial/test/CMakeLists.txt
+++ b/src/leapserial/test/CMakeLists.txt
@@ -32,7 +32,12 @@ add_conditional_sources(
   TestObject_generated.h
 )
 
-find_package(Protobuf 2.5.0 QUIET)
+if(LS_PROTOBUF_REQUIRED)
+  find_package(Protobuf 2.5.0 REQUIRED)
+else()
+  find_package(Protobuf 2.5.0 QUIET)
+endif()
+
 if(Protobuf_FOUND)
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.pb.cc ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.pb.h

--- a/src/leapserial/test/TestProtobuf.proto
+++ b/src/leapserial/test/TestProtobuf.proto
@@ -1,0 +1,40 @@
+package leap.test;
+
+message Pet {
+  required string name = 1;
+
+  enum Species {
+    DOG = 0;
+    CAT = 1;
+  }
+  required Species species = 2;
+}
+
+message PetFieldEntry{
+  required string key = 1;
+  required Pet value = 2;
+}
+
+message Person {
+  required string name = 1;
+  required int32 id = 2;
+  optional string email = 3;
+
+  enum PhoneType {
+    MOBILE = 0;
+    HOME = 1;
+    WORK = 2;
+  }
+
+  message PhoneNumber {
+    required string number = 1;
+    optional PhoneType type = 2[default = HOME];
+  }
+
+  repeated PhoneNumber phone = 4;
+  repeated PetFieldEntry pet = 5;
+}
+
+message AddressBook {
+  repeated Person person = 1;
+}


### PR DESCRIPTION
This formatter will allow LeapSerial structures to target the protobuf wire format.  Protobuf wire-level compatibility makes it possible to interop with protobuf comms layers without needing to generate a .proto file.

This formatter is only meant to be an initial implementation, and will be tested but not to the extreme.  Subsequent pull requests should ensure the implementation is adequately tested for general use.

- [x] Ensure travis is building the protobufs unit tests