### PR TITLE
Fix whitespace scripts

### DIFF
--- a/scripts/copyright_check.sh
+++ b/scripts/copyright_check.sh
@@ -4,7 +4,7 @@
 # Enforce LeapMotion copyright notice
 #
 
-ENFORCED_FILES="autowiring examples src"
+ENFORCED_FILES="LeapSerial src"
 COPYRIGHT_HEADER="// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved."
 
 # Go to root directory

--- a/scripts/whitespace_check.sh
+++ b/scripts/whitespace_check.sh
@@ -4,7 +4,7 @@
 # Enforce spaces instead of tabs
 #
 
-ENFORCED_FILES="autowiring examples src CMakeLists.txt"
+ENFORCED_FILES="LeapSerial src CMakeLists.txt"
 
 # Go to root directory
 


### PR DESCRIPTION
Looks like this still has paths that were valid in Autowiring but are not valid here, fix the linter script to reflect the current directory structure.