### PR TITLE
Fix error uncovered during unit testing

### DIFF
--- a/LeapSerial/ArchiveProtobuf.h
+++ b/LeapSerial/ArchiveProtobuf.h
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Archive.h"
 #include "IArchiveProtobuf.h"

--- a/LeapSerial/IArchiveProtobuf.h
+++ b/LeapSerial/IArchiveProtobuf.h
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Archive.h"
 

--- a/LeapSerial/IArchiveProtobuf.h
+++ b/LeapSerial/IArchiveProtobuf.h
@@ -27,7 +27,7 @@ namespace leap {
     void* ReadObjectReference(const create_delete& cd, const field_serializer& desc) override;
 
   private:
-    void ReadSingle(const descriptor& descriptor, void* pObj);
+    bool ReadSingle(const descriptor& descriptor, void* pObj);
 
     // Descriptor of current object being read, if any exist:
     const descriptor* m_pCurDesc = nullptr;


### PR DESCRIPTION
Caused by an unbounded/torn dictionary read operation and an EOF check that was occuring way too late.