### PR TITLE
General namespace cleanup

### DIFF
--- a/LeapSerial/serialization_error.h
+++ b/LeapSerial/serialization_error.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <stdexcept>
+#include <string>
+
+namespace leap {
+  struct serialization_error :
+    public std::runtime_error
+  {
+    serialization_error(std::string what);
+  };
+}

--- a/LeapSerial/serialization_error.h
+++ b/LeapSerial/serialization_error.h
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <stdexcept>
 #include <string>

--- a/src/leapserial/CMakeLists.txt
+++ b/src/leapserial/CMakeLists.txt
@@ -21,13 +21,15 @@ set(LeapSerial_SRCS
   IArchiveImpl.cpp
   IArray.h
   IDictionary.h
+  LeapSerial.h
   OArchiveImpl.h
   OArchiveImpl.cpp
   optional.h
   ProtobufUtil.cpp
   ProtobufUtil.hpp
-  LeapSerial.h
   serial_traits.h
+  serialization_error.h
+  serialization_error.cpp
   Utility.hpp
   Utility.cpp
 )

--- a/src/leapserial/IArchiveProtobuf.cpp
+++ b/src/leapserial/IArchiveProtobuf.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 
 using namespace leap;
+using leap::internal::protobuf::WireType;
 
 IArchiveProtobuf::IArchiveProtobuf(IInputStream& is) :
   is(is)
@@ -31,29 +32,29 @@ bool IArchiveProtobuf::ReadSingle(const descriptor& descriptor, void* pObj) {
   if (is.IsEof())
     return false;
 
-  protobuf::WireType type = static_cast<protobuf::WireType>(v & 7);
+  WireType type = static_cast<WireType>(v & 7);
   uint64_t ident = v >> 3;
 
   auto q = descriptor.identified_descriptors.find(ident);
   if (q == descriptor.identified_descriptors.end())
     // Skip behavior
     switch (type) {
-    case protobuf::WireType::Varint:
+    case WireType::Varint:
       ReadInteger(0);
       break;
-    case protobuf::WireType::LenDelimit:
+    case WireType::LenDelimit:
       Skip(ReadInteger(0));
       break;
-    case protobuf::WireType::DoubleWord:
+    case WireType::DoubleWord:
       Skip(4);
       break;
-    case protobuf::WireType::QuadWord:
+    case WireType::QuadWord:
       Skip(8);
       break;
-    case protobuf::WireType::StartGroup:
-    case protobuf::WireType::EndGroup:
+    case WireType::StartGroup:
+    case WireType::EndGroup:
       throw std::runtime_error("Unexpected protobuf wire type");
-    case protobuf::WireType::ObjReference:
+    case WireType::ObjReference:
       throw std::runtime_error("Cannot serialize object references");
     }
   else
@@ -68,7 +69,7 @@ bool IArchiveProtobuf::ReadSingle(const descriptor& descriptor, void* pObj) {
 
 void IArchiveProtobuf::ReadDescriptor(const descriptor& descriptor, void* pObj, uint64_t ncb) {
   if (!descriptor.field_descriptors.empty())
-    throw leap::protobuf::serialization_error{ descriptor };
+    throw leap::internal::protobuf::serialization_error{ descriptor };
 
   if (m_pCurDesc)
     // We are not the root type.  The root type is not length-delimited, but all embedded messages

--- a/src/leapserial/ProtobufUtil.cpp
+++ b/src/leapserial/ProtobufUtil.cpp
@@ -7,28 +7,29 @@
 #include <sstream>
 
 using namespace leap;
+using leap::internal::protobuf::WireType;
 
-protobuf::WireType leap::protobuf::ToWireType(serial_atom atom) {
+WireType leap::internal::protobuf::ToWireType(serial_atom atom) {
   switch (atom) {
   case serial_atom::boolean:
   case serial_atom::i8:
   case serial_atom::i16:
   case serial_atom::i32:
   case serial_atom::i64:
-    return protobuf::WireType::Varint;
+    return WireType::Varint;
   case serial_atom::f32:
-    return protobuf::WireType::DoubleWord;
+    return WireType::DoubleWord;
   case serial_atom::f64:
-    return protobuf::WireType::QuadWord;
+    return WireType::QuadWord;
   case serial_atom::reference:
   case serial_atom::array:
-    return protobuf::WireType::LenDelimit;
+    return WireType::LenDelimit;
   case serial_atom::string:
-    return protobuf::WireType::LenDelimit;
+    return WireType::LenDelimit;
   case serial_atom::map:
     break;
   case serial_atom::descriptor:
-    return protobuf::WireType::LenDelimit;
+    return WireType::LenDelimit;
   case serial_atom::finalized_descriptor:
     break;
   case serial_atom::ignored:
@@ -40,16 +41,16 @@ protobuf::WireType leap::protobuf::ToWireType(serial_atom atom) {
 static std::string FormatError(const descriptor& descriptor) {
   std::stringstream ss;
   ss << "The OArchiveProtobuf requires that all entries have identifiers" << std::endl
-     << "Fields at the following offsets do not have identifiers:" << std::endl;
+    << "Fields at the following offsets do not have identifiers:" << std::endl;
   for (const auto& field_descriptor : descriptor.field_descriptors)
     ss << "[ " << std::left << std::setw(8) << ToString(field_descriptor.serializer.type()) << " ] @+" << field_descriptor.offset << std::endl;
   return ss.str();
 }
 
-protobuf::serialization_error::serialization_error(std::string what) :
-  std::runtime_error(std::move(what))
+internal::protobuf::serialization_error::serialization_error(std::string&& err) :
+  ::leap::serialization_error(std::move(err))
 {}
 
-protobuf::serialization_error::serialization_error(const descriptor& descriptor) :
-  std::runtime_error(FormatError(descriptor))
+internal::protobuf::serialization_error::serialization_error(const descriptor& descriptor) :
+  ::leap::serialization_error(FormatError(descriptor))
 {}

--- a/src/leapserial/ProtobufUtil.hpp
+++ b/src/leapserial/ProtobufUtil.hpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include "serialization_error.h"
 #include <memory>
 #include <stdexcept>
 
@@ -7,26 +8,28 @@ namespace leap {
   struct descriptor;
   enum class serial_atom;
 
-  namespace protobuf {
-    enum class WireType {
-      Varint = 0,
-      QuadWord = 1,
-      LenDelimit = 2,
-      StartGroup = 3,  // Deprecated
-      EndGroup = 4,    // Deprecated
-      DoubleWord = 5,
+  namespace internal {
+    namespace protobuf {
+      enum class WireType {
+        Varint = 0,
+        QuadWord = 1,
+        LenDelimit = 2,
+        StartGroup = 3,  // Deprecated
+        EndGroup = 4,    // Deprecated
+        DoubleWord = 5,
 
-      // Nonstandard extension
-      ObjReference = 7
-    };
+        // Nonstandard extension
+        ObjReference = 7
+      };
 
-    protobuf::WireType ToWireType(serial_atom atom);
+      protobuf::WireType ToWireType(serial_atom atom);
 
-    struct serialization_error :
-      public std::runtime_error
-    {
-      serialization_error(std::string what);
-      serialization_error(const descriptor& descriptor);
-    };
+      struct serialization_error :
+        public ::leap::serialization_error
+      {
+        serialization_error(std::string&& err);
+        serialization_error(const descriptor& descriptor);
+      };
+    }
   }
 }

--- a/src/leapserial/serialization_error.cpp
+++ b/src/leapserial/serialization_error.cpp
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "serialization_error.h"
 

--- a/src/leapserial/serialization_error.cpp
+++ b/src/leapserial/serialization_error.cpp
@@ -1,0 +1,6 @@
+#include "stdafx.h"
+#include "serialization_error.h"
+
+leap::serialization_error::serialization_error(std::string what) :
+  std::runtime_error(std::move(what))
+{}


### PR DESCRIPTION
Move `protobuf` to the internal namespace, create a separate `serialization_exception` base type to report all serialization-related exceptions.