### PR TITLE
Split IInputStream and IOutputStream into their own headers

### DIFF
--- a/LeapSerial/IInputStream.h
+++ b/LeapSerial/IInputStream.h
@@ -1,0 +1,33 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include <iosfwd>
+
+namespace leap {
+  /// <summary>
+  /// Stream adaptor interface for use with the Archive type
+  /// </summary>
+  class IInputStream {
+  public:
+    virtual ~IInputStream(void) {}
+
+    /// <returns>
+    /// False if the next call to Read might succeed
+    /// </returns>
+    virtual bool IsEof(void) const = 0;
+
+    /// <summary>
+    /// Reads exactly the specified number of bytes from the input stream
+    /// </summary>
+    /// <returns>
+    /// The number of bytes actually read, -1 if there was an error.  The number of bytes read
+    /// may be less than the number of bytes requested if the end of the file was encountered
+    /// before the operation completed.
+    /// </returns>
+    virtual std::streamsize Read(void* pBuf, std::streamsize ncb) = 0;
+
+    /// <summary>
+    /// Discards the specified number of bytes from the input stream
+    /// </summary>
+    virtual std::streamsize Skip(std::streamsize ncb) = 0;
+  };
+}

--- a/LeapSerial/IOutputStream.h
+++ b/LeapSerial/IOutputStream.h
@@ -1,0 +1,18 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include <iosfwd>
+
+namespace leap {
+  /// <summary>
+  /// Stream adaptor interface for use with the Archive type
+  /// </summary>
+  class IOutputStream {
+  public:
+    virtual ~IOutputStream(void) {}
+
+    /// <summary>
+    /// Writes all of the specified bytes to the output stream
+    /// </summary>
+    virtual bool Write(const void* pBuf, std::streamsize ncb) = 0;
+  };
+}

--- a/src/leapserial/CMakeLists.txt
+++ b/src/leapserial/CMakeLists.txt
@@ -21,6 +21,8 @@ set(LeapSerial_SRCS
   IArchiveImpl.cpp
   IArray.h
   IDictionary.h
+  IInputStream.h
+  IOutputStream.h
   OArchiveImpl.h
   OArchiveImpl.cpp
   optional.h


### PR DESCRIPTION
These types are interfaces, they should be defined in a minimum-dependency setting