### PR TITLE
Add an interface concept for array, map, and object types

### DIFF
--- a/LeapSerial/Descriptor.h
+++ b/LeapSerial/Descriptor.h
@@ -12,7 +12,24 @@ namespace leap {
   class OArchiveRegistry;
 
   template<typename T, typename>
+  struct primitive_serial_traits;
+
+  template<typename T, typename>
   struct field_serializer_t;
+
+  /// <summary>
+  /// Holds "true" if T::GetDescriptor exists
+  /// </summary>
+  template<class T>
+  struct has_getdescriptor {
+    template<class U>
+    static std::true_type select(decltype(U::GetDescriptor)*);
+
+    template<class U>
+    static std::false_type select(...);
+
+    static const bool value = decltype(select<T>(nullptr))::value;
+  };
 
   /// <summary>
   /// Provides a generic way to describe serializable fields in a class
@@ -41,5 +58,35 @@ namespace leap {
     uint64_t size(const OArchiveRegistry& ar, const void* pObj) const override;
     void serialize(OArchiveRegistry& ar, const void* pObj) const override;
     void deserialize(IArchiveRegistry& ar, void* pObj, uint64_t ncb) const override;
+  };
+
+  // Embedded object types should use their corresponding descriptors
+  template<typename T>
+  struct primitive_serial_traits<T, typename std::enable_if<has_getdescriptor<T>::value>::type>
+  {
+    static const bool is_object = true;
+
+    static ::leap::serial_atom type() {
+      return get_descriptor().type();
+    }
+
+    // Trivial serialization/deserialization operations
+    static uint64_t size(const OArchiveRegistry& ar, const T& obj) {
+      return get_descriptor().size(ar, &obj);
+    }
+
+    static void serialize(OArchiveRegistry& ar, const T& obj) {
+      get_descriptor().serialize(ar, &obj);
+    }
+
+    static void deserialize(IArchiveRegistry& ar, T& obj, uint64_t ncb) {
+      get_descriptor().deserialize(ar, &obj, ncb);
+    }
+
+    // GetDescriptor is defined for our type, we can invoke it
+    static const descriptor& get_descriptor(void) {
+      static const descriptor desc = T::GetDescriptor();
+      return desc;
+    }
   };
 }

--- a/LeapSerial/field_serializer.h
+++ b/LeapSerial/field_serializer.h
@@ -80,4 +80,31 @@ namespace leap {
     virtual void deserialize(IArchiveRegistry& ar, void* pObj, uint64_t ncb) const = 0;
   };
 
+  /// <summary>
+  /// Describes a serializer concept for an embedded object
+  /// </summary>
+  struct field_serializer_object :
+    field_serializer
+  {
+    virtual const descriptor& object(void) const = 0;
+  };
+
+  /// <summary>
+  /// Describes a serializer concept for an array
+  /// </summary>
+  struct field_serializer_array :
+    field_serializer
+  {
+    virtual const field_serializer& element(void) const = 0;
+  };
+
+  /// <summary>
+  /// Describes a serializer concept for a map
+  /// </summary>
+  struct field_serializer_map:
+    field_serializer
+  {
+    virtual const field_serializer& key(void) const = 0;
+    virtual const field_serializer& mapped(void) const = 0;
+  };
 }

--- a/LeapSerial/serial_traits.h
+++ b/LeapSerial/serial_traits.h
@@ -12,8 +12,6 @@
 #include <vector>
 
 namespace leap {
-  struct descriptor;
-
   template<typename T>
   struct serial_traits;
 
@@ -41,52 +39,6 @@ namespace leap {
   struct create_delete {
     void* (*pfnAlloc)();
     void(*pfnFree)(void*);
-  };
-
-  namespace internal {
-    /// <summary>
-    /// Holds "true" if T::GetDescriptor exists
-    /// </summary>
-    template<class T>
-    struct has_getdescriptor {
-      template<class U>
-      static std::true_type select(decltype(U::GetDescriptor)*);
-
-      template<class U>
-      static std::false_type select(...);
-
-      static const bool value = decltype(select<T>(nullptr))::value;
-    };
-  }
-
-  // Embedded object types should use their corresponding descriptors
-  template<typename T>
-  struct primitive_serial_traits<T, typename std::enable_if<internal::has_getdescriptor<T>::value>::type>
-  {
-    static const bool is_object = true;
-
-    static ::leap::serial_atom type() {
-      return get_descriptor().type();
-    }
-
-    // Trivial serialization/deserialization operations
-    static uint64_t size(const OArchiveRegistry& ar, const T& obj) {
-      return get_descriptor().size(ar, &obj);
-    }
-
-    static void serialize(OArchiveRegistry& ar, const T& obj) {
-      get_descriptor().serialize(ar, &obj);
-    }
-
-    static void deserialize(IArchiveRegistry& ar, T& obj, uint64_t ncb) {
-      get_descriptor().deserialize(ar, &obj, ncb);
-    }
-
-    // GetDescriptor is defined for our type, we can invoke it
-    static const descriptor& get_descriptor(void) {
-      static const auto desc = T::GetDescriptor();
-      return desc;
-    }
   };
 
   // Specialization for anything that is a floating-point type.  These can be written directly to disk,

--- a/src/leapserial/test/SerializationTest.cpp
+++ b/src/leapserial/test/SerializationTest.cpp
@@ -73,7 +73,7 @@ static_assert(
   >::value,
   "Could not infer GetDescriptor return type"
 );
-static_assert(leap::internal::has_getdescriptor<MySimpleStructure>::value, "GetDescriptor not detected on MySimpleStructure");
+static_assert(leap::has_getdescriptor<MySimpleStructure>::value, "GetDescriptor not detected on MySimpleStructure");
 
 TEST_F(SerializationTest, VerifyTrivialDescriptor) {
   // Obtain the descriptor for the simple structure first, verify all properties


### PR DESCRIPTION
This allows reflection to be done on these types, where formerly the whole serialization process was quite opaque.