### PR TITLE
Add name concept to LeapSerial descriptor

### DIFF
--- a/LeapSerial/Descriptor.h
+++ b/LeapSerial/Descriptor.h
@@ -20,14 +20,23 @@ namespace leap {
   struct descriptor:
     field_serializer
   {
+    descriptor(const char* name, std::initializer_list<field_descriptor> field_descriptors) :
+      descriptor(name, field_descriptors.begin(), field_descriptors.end())
+    {}
     descriptor(std::initializer_list<field_descriptor> field_descriptors) :
-      descriptor(field_descriptors.begin(), field_descriptors.end())
+      descriptor(nullptr, field_descriptors.begin(), field_descriptors.end())
+    {}
+    descriptor(const field_descriptor* begin, const field_descriptor* end) :
+      descriptor(nullptr, begin, end)
     {}
 
-    descriptor(const field_descriptor* begin, const field_descriptor* end);
+    descriptor(const char* name, const field_descriptor* begin, const field_descriptor* end);
 
     // Allocation flag
     bool m_allocates = false;
+
+    // Holds the descriptor's symbolic name, if one has been provided
+    const char* const name = nullptr;
 
     // Required field descriptors
     std::vector<field_descriptor> field_descriptors;

--- a/src/leapserial/Descriptor.cpp
+++ b/src/leapserial/Descriptor.cpp
@@ -6,7 +6,9 @@
 
 using namespace leap;
 
-leap::descriptor::descriptor(const field_descriptor* begin, const field_descriptor* end) {
+leap::descriptor::descriptor(const char* name, const field_descriptor* begin, const field_descriptor* end) :
+  name(name)
+{
   for (auto cur = begin; cur != end; cur++) {
     const auto& field_descriptor = *cur;
     if (field_descriptor.identifier)


### PR DESCRIPTION
This allows users to provide string names for their datatypes for reflection purposes.  This might be replaced at a later date with an `autowiring::demangle` variant, but for now we'll encourage manual naming.