### PR TITLE
Move protobuf reference class to its own header

### DIFF
--- a/src/leapserial/test/ArchiveProtobufTest.cpp
+++ b/src/leapserial/test/ArchiveProtobufTest.cpp
@@ -3,6 +3,7 @@
 #include "LeapSerial.h"
 #include "IArchiveProtobuf.h"
 #include "OArchiveProtobuf.h"
+#include "TestProtobufLS.hpp"
 #include <gtest/gtest.h>
 #include <sstream>
 
@@ -10,76 +11,6 @@
 #define _SCL_SECURE_NO_WARNINGS
 #include "TestProtobuf.pb.h"
 #undef _SCL_SECURE_NO_WARNINGS
-
-namespace {
-  class PhoneNumber {
-  public:
-    enum PhoneType {
-      MOBILE,
-      HOME,
-      WORK
-    };
-
-    std::string number;
-    PhoneType type;
-
-    bool operator==(const PhoneNumber& rhs) const {
-      return number == rhs.number && type == rhs.type;
-    }
-
-    static leap::descriptor GetDescriptor(void) {
-      return{
-        { 1, &PhoneNumber::number },
-        { 2, &PhoneNumber::type }
-      };
-    }
-  };
-
-  class Pet {
-  public:
-    std::string name;
-
-    enum class Species {
-      DOG = 0,
-      CAT = 1
-    };
-    Species species;
-
-    static leap::descriptor GetDescriptor(void) {
-      return {
-        { 1, &Pet::name },
-        { 2, &Pet::species }
-      };
-    }
-  };
-
-  class Person {
-  public:
-    std::string name;
-    int id;
-    std::string email;
-    std::vector<PhoneNumber> phone;
-    std::map<std::string, Pet> pets;
-
-    bool operator==(const Person& rhs) const {
-      return
-        name == rhs.name &&
-        id == rhs.id &&
-        email == rhs.email &&
-        phone == rhs.phone;
-    }
-
-    static leap::descriptor GetDescriptor(void) {
-      return {
-        { 1, &Person::name },
-        { 2, &Person::id },
-        { 3, &Person::email },
-        { 4, &Person::phone },
-        { 5, &Person::pets }
-      };
-    }
-  };
-}
 
 static std::string ToProtobuf(const Person& in) {
   // Write the protobuf version first:

--- a/src/leapserial/test/CMakeLists.txt
+++ b/src/leapserial/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LeapSerialTest_SRCS
   SerialFormatTest.cpp
   SerializationTest.cpp
   TestObject.h
+  TestProtobufLS.hpp
 )
 add_pch(LeapSerialTest_SRCS "stdafx.h" "stdafx.cpp")
 

--- a/src/leapserial/test/TestProtobufLS.hpp
+++ b/src/leapserial/test/TestProtobufLS.hpp
@@ -1,0 +1,75 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include <map>
+#include <string>
+#include <vector>
+
+namespace {
+  class PhoneNumber {
+  public:
+    enum PhoneType {
+      MOBILE,
+      HOME,
+      WORK
+    };
+
+    std::string number;
+    PhoneType type;
+
+    bool operator==(const PhoneNumber& rhs) const {
+      return number == rhs.number && type == rhs.type;
+    }
+
+    static leap::descriptor GetDescriptor(void) {
+      return{
+        { 1, &PhoneNumber::number },
+        { 2, &PhoneNumber::type }
+      };
+    }
+  };
+
+  class Pet {
+  public:
+    std::string name;
+
+    enum class Species {
+      DOG = 0,
+      CAT = 1
+    };
+    Species species;
+
+    static leap::descriptor GetDescriptor(void) {
+      return{
+        { 1, &Pet::name },
+        { 2, &Pet::species }
+      };
+    }
+  };
+
+  class Person {
+  public:
+    std::string name;
+    int id;
+    std::string email;
+    std::vector<PhoneNumber> phone;
+    std::map<std::string, Pet> pets;
+
+    bool operator==(const Person& rhs) const {
+      return
+        name == rhs.name &&
+        id == rhs.id &&
+        email == rhs.email &&
+        phone == rhs.phone;
+    }
+
+    static leap::descriptor GetDescriptor(void) {
+      return{
+        { 1, &Person::name },
+        { 2, &Person::id },
+        { 3, &Person::email },
+        { 4, &Person::phone },
+        { 5, &Person::pets }
+      };
+    }
+  };
+}


### PR DESCRIPTION
Should be useful for other tests, put it in a common location.