### PR TITLE
Add an explicit overload to field_descriptor for synthetic types

### DIFF
--- a/LeapSerial/Descriptor.h
+++ b/LeapSerial/Descriptor.h
@@ -53,7 +53,7 @@ namespace leap {
     bool m_allocates = false;
 
     // Holds the descriptor's symbolic name, if one has been provided
-    const char* const name = nullptr;
+    const char* name = nullptr;
 
     // Required field descriptors
     std::vector<field_descriptor> field_descriptors;

--- a/LeapSerial/field_descriptor.h
+++ b/LeapSerial/field_descriptor.h
@@ -229,6 +229,13 @@ namespace leap {
       serializer(field_serializer_t<Base, void>::GetDescriptor())
     {}
 
+    field_descriptor(const field_serializer& serializer, const char* name, int identifier, size_t offset) :
+      serializer(serializer),
+      name(name),
+      identifier(identifier),
+      offset(offset)
+    {}
+
     // Serializer interface, actually implements our serialization operation
     const field_serializer& serializer;
 


### PR DESCRIPTION
We will likely need this often when we do schema formatting, add it.  Also make `descriptor::name` non-const so we can reassign it at runtime.