### PR TITLE
Add protobuf schema writer and unit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
           - libc6-i386
           - protobuf-compiler
           - libprotobuf-dev
+          - libprotoc-dev
   - os: osx
     env:
     - _CC: clang

--- a/LeapSerial/LeapSerial.h
+++ b/LeapSerial/LeapSerial.h
@@ -37,7 +37,7 @@ namespace leap {
 
   template<typename archive_t, typename stream_t>
   void Serialize(stream_t&& os, const leap::descriptor& desc) {
-    archive_t::schema s{ desc };
+    typename archive_t::schema s{ desc };
     s.Write(os);
   }
 

--- a/LeapSerial/LeapSerial.h
+++ b/LeapSerial/LeapSerial.h
@@ -2,10 +2,13 @@
 #pragma once
 #include "Allocation.h"
 #include "Archive.h"
-#include "IArchiveImpl.h"
-#include "OArchiveImpl.h"
 #include "Descriptor.h"
 #include "field_serializer.h"
+#include "IArchiveImpl.h"
+#include "IArchiveProtobuf.h"
+#include "OArchiveImpl.h"
+#include "OArchiveProtobuf.h"
+#include "SchemaWriterProtobuf.h"
 #include <memory>
 #include <istream>
 
@@ -15,7 +18,30 @@ namespace leap {
   template<typename T, typename>
   struct field_serializer_t;
 
-  template<class archive_t, class stream_t, class T>
+  struct leapserial {
+    typedef IArchiveImpl iarchive;
+    typedef OArchiveImpl oarchive;
+  };
+
+  struct protobuf_v1 {
+    typedef IArchiveProtobuf iarchive;
+    typedef OArchiveProtobuf oarchive;
+    typedef SchemaWriterProtobuf schema;
+  };
+
+  struct protobuf_v2 {
+    typedef IArchiveProtobuf iarchive;
+    typedef OArchiveProtobuf oarchive;
+    typedef SchemaWriterProtobuf2 schema;
+  };
+
+  template<typename archive_t, typename stream_t>
+  void Serialize(stream_t&& os, const leap::descriptor& desc) {
+    archive_t::schema s{ desc };
+    s.Write(os);
+  }
+
+  template<typename archive_t, typename stream_t, typename T>
   void Serialize(stream_t&& os, const T& obj) {
     static_assert(!std::is_pointer<T>::value, "Do not serialize a pointer to an object, serialize a reference");
     static_assert(

--- a/LeapSerial/SchemaWriterProtobuf.h
+++ b/LeapSerial/SchemaWriterProtobuf.h
@@ -1,0 +1,62 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "IOutputStream.h"
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+namespace leap {
+  struct descriptor;
+  struct field_serializer;
+
+  namespace protobuf {
+    enum class Version {
+      Proto1,
+      Proto2,
+      Proto3
+    };
+  }
+
+  /// <summary>
+  /// Writes the complete schema rooted at some specified descriptor
+  /// </summary>
+  class SchemaWriterProtobuf
+  {
+  public:
+    SchemaWriterProtobuf(const descriptor& desc, protobuf::Version version = protobuf::Version::Proto1);
+
+    const descriptor& Desc;
+    const protobuf::Version Version;
+
+  private:
+    // Current tab level
+    size_t tabLevel = 0;
+
+    // Types to be written:
+    std::vector<const descriptor*> awaiting;
+
+    // Types already encountered:
+    std::unordered_set<const descriptor*> encountered;
+
+    // Synthetic types we had to create while parsing:
+    std::vector<std::unique_ptr<descriptor>> synthetic;
+    std::vector<std::string> syntheticNames;
+
+    // Manipulators
+    struct indent;
+    struct name;
+    struct type;
+
+  public:
+    void Write(IOutputStream& os);
+    void Write(std::ostream& os);
+  };
+
+  class SchemaWriterProtobuf2:
+    SchemaWriterProtobuf
+  {
+    SchemaWriterProtobuf2(const descriptor& desc) :
+      SchemaWriterProtobuf(desc, protobuf::Version::Proto2)
+    {}
+  };
+}

--- a/src/leapserial/CMakeLists.txt
+++ b/src/leapserial/CMakeLists.txt
@@ -29,6 +29,8 @@ set(LeapSerial_SRCS
   optional.h
   ProtobufUtil.cpp
   ProtobufUtil.hpp
+  SchemaWriterProtobuf.h
+  SchemaWriterProtobuf.cpp
   serial_traits.h
   serialization_error.h
   serialization_error.cpp

--- a/src/leapserial/ProtobufUtil.cpp
+++ b/src/leapserial/ProtobufUtil.cpp
@@ -42,6 +42,42 @@ WireType leap::internal::protobuf::ToWireType(serial_atom atom) {
   throw std::invalid_argument("Attempted to find a wire type for an unrecognized serial atom type");
 }
 
+const char* leap::internal::protobuf::ToProtobufField(serial_atom atom) {
+  switch (atom) {
+  case serial_atom::boolean:
+    return "bool";
+  case serial_atom::i8:
+  case serial_atom::i16:
+  case serial_atom::i32:
+    return "sint32";
+  case serial_atom::i64:
+    return "sint64";
+  case serial_atom::ui8:
+  case serial_atom::ui16:
+  case serial_atom::ui32:
+    return "int32";
+  case serial_atom::ui64:
+    return "int64";
+  case serial_atom::f32:
+    return "float";
+  case serial_atom::f64:
+    return "double";
+  case serial_atom::reference:
+    break;
+  case serial_atom::array:
+  case serial_atom::string:
+    return "string";
+  case serial_atom::map:
+    break;
+  case serial_atom::descriptor:
+  case serial_atom::finalized_descriptor:
+    break;
+  case serial_atom::ignored:
+    throw std::invalid_argument("Invalid serial atom type");
+  }
+  throw std::invalid_argument("Attempted to obtain the protobuf field of a non-value type");
+}
+
 static std::string FormatError(const descriptor& descriptor) {
   std::stringstream ss;
   ss << "The OArchiveProtobuf requires that all entries have identifiers" << std::endl

--- a/src/leapserial/ProtobufUtil.hpp
+++ b/src/leapserial/ProtobufUtil.hpp
@@ -24,6 +24,8 @@ namespace leap {
 
       protobuf::WireType ToWireType(serial_atom atom);
 
+      const char* ToProtobufField(serial_atom atom);
+
       struct serialization_error :
         public ::leap::serialization_error
       {

--- a/src/leapserial/SchemaWriterProtobuf.cpp
+++ b/src/leapserial/SchemaWriterProtobuf.cpp
@@ -31,7 +31,7 @@ struct SchemaWriterProtobuf::name {
       os << rhs.desc.name;
     else
       // Need to derive a locally valid name
-      os << "msg_" << std::hex << std::setfill('0') << std::setw(8) << reinterpret_cast<uint32_t>(&rhs.desc);
+      os << "msg_" << std::hex << std::setfill('0') << std::setw(8) << static_cast<uint32_t>(reinterpret_cast<size_t>(&rhs.desc));
     return os;
   }
 };
@@ -74,7 +74,7 @@ struct SchemaWriterProtobuf::type {
             std::string* pSyntheticName;
             {
               std::stringstream ss;
-              ss << "MapEntry_" << std::hex << std::setw(8) << std::setfill('0') << reinterpret_cast<uint32_t>(&pDesc);
+              ss << "MapEntry_" << std::hex << std::setw(8) << std::setfill('0') << static_cast<uint32_t>(reinterpret_cast<size_t>(&pDesc));
               parent.syntheticNames.emplace_back(ss.str());
               pSyntheticName = &parent.syntheticNames.back();
             }

--- a/src/leapserial/SchemaWriterProtobuf.cpp
+++ b/src/leapserial/SchemaWriterProtobuf.cpp
@@ -3,6 +3,7 @@
 #include "SchemaWriterProtobuf.h"
 #include "Descriptor.h"
 #include "ProtobufUtil.hpp"
+#include <iomanip>
 #include <sstream>
 
 using namespace leap;

--- a/src/leapserial/SchemaWriterProtobuf.cpp
+++ b/src/leapserial/SchemaWriterProtobuf.cpp
@@ -1,0 +1,159 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "SchemaWriterProtobuf.h"
+#include "Descriptor.h"
+#include "ProtobufUtil.hpp"
+#include <sstream>
+
+using namespace leap;
+
+SchemaWriterProtobuf::SchemaWriterProtobuf(const descriptor& desc, protobuf::Version version) :
+  Desc(desc),
+  Version(version)
+{}
+
+struct SchemaWriterProtobuf::indent {
+  indent(size_t level) : level(level) {}
+  const size_t level;
+  friend std::ostream& operator<<(std::ostream& os, const indent& rhs) {
+    for (size_t i = rhs.level; i--;)
+      os << "  ";
+    return os;
+  }
+};
+
+struct SchemaWriterProtobuf::name {
+  name(const descriptor& desc) : desc(desc) {}
+  const descriptor& desc;
+  friend std::ostream& operator<<(std::ostream& os, const name& rhs) {
+    if (rhs.desc.name)
+      os << rhs.desc.name;
+    else
+      // Need to derive a locally valid name
+      os << "msg_" << std::hex << std::setfill('0') << std::setw(8) << reinterpret_cast<uint32_t>(&rhs.desc);
+    return os;
+  }
+};
+
+struct SchemaWriterProtobuf::type {
+  type(SchemaWriterProtobuf& parent, const field_serializer& ser, bool print_req = true) :
+    parent(parent),
+    ser(ser),
+    print_req(print_req)
+  {}
+  
+  SchemaWriterProtobuf& parent;
+  const field_serializer& ser;
+  bool print_req = true;
+
+  const char* signifier(void) const {
+    return
+      !print_req ?
+      "" :
+      ser.is_optional() ?
+      "optional " :
+      "required ";
+  }
+
+  std::ostream& print(std::ostream& os) const {
+    switch (auto atom = ser.type()) {
+    case serial_atom::array:
+      // "repeated" field, entry type knows more
+      return os << "repeated " << type{ parent, dynamic_cast<const field_serializer_array&>(ser).element(), false };
+
+    case serial_atom::map:
+      {
+        const auto& ser_map = dynamic_cast<const field_serializer_map&>(ser);
+        switch(parent.Version) {
+        case protobuf::Version::Proto1:
+          {
+            parent.synthetic.emplace_back(nullptr);
+            std::unique_ptr<leap::descriptor>& pDesc = parent.synthetic.back();
+
+            std::string* pSyntheticName;
+            {
+              std::stringstream ss;
+              ss << "MapEntry_" << std::hex << std::setw(8) << std::setfill('0') << reinterpret_cast<uint32_t>(&pDesc);
+              parent.syntheticNames.emplace_back(ss.str());
+              pSyntheticName = &parent.syntheticNames.back();
+            }
+            pDesc = std::unique_ptr<leap::descriptor> {
+              new leap::descriptor{
+                pSyntheticName->c_str(),
+                {
+                  leap::field_descriptor { ser_map.key(), "key", 1, ~0UL },
+                  leap::field_descriptor { ser_map.mapped(), "value", 2, ~0UL }
+                }
+              }
+            };
+            parent.awaiting.push_back(pDesc.get());
+            os << "repeated " << *pSyntheticName;
+          }
+          break;
+        case protobuf::Version::Proto2:
+        case protobuf::Version::Proto3:
+          return os
+            << signifier()
+            << "map<"
+            << type{ parent, ser_map.key() }
+            << ','
+            << type{ parent, ser_map.mapped() }
+            << '>';
+        }
+      }
+      break;
+    case serial_atom::descriptor:
+    case serial_atom::finalized_descriptor:
+      // Need to generate a reference to this type by name:
+      {
+        const auto& f_ser_obj = dynamic_cast<const field_serializer_object&>(ser);
+        const auto& ser_obj = f_ser_obj.object();
+        parent.awaiting.push_back(&ser_obj);
+        return os << signifier() << name{ ser_obj };
+      }
+    default:
+      // Type is fundamental
+      return os
+        << signifier()
+        << leap::internal::protobuf::ToProtobufField(atom);
+    }
+    return os;
+  }
+  friend std::ostream& operator<<(std::ostream& os, const type& rhs) { return rhs.print(os); }
+};
+
+void SchemaWriterProtobuf::Write(IOutputStream& os) {
+  std::stringstream ss;
+  Write(ss);
+  auto str = ss.str();
+  os.Write(str.data(), str.size());
+}
+
+void SchemaWriterProtobuf::Write(std::ostream& os) {
+  awaiting.push_back(&Desc);
+  encountered.clear();
+  synthetic.clear();
+  syntheticNames.clear();
+
+  while (!awaiting.empty()) {
+    const descriptor& cur = *awaiting.back();
+    awaiting.pop_back();
+
+    if (encountered.count(&cur))
+      continue;
+    encountered.insert(&cur);
+
+    os << "message " << name(cur) << " {" << std::endl;
+    for (auto& e : cur.identified_descriptors) {
+      os << indent(tabLevel + 1) << type(*this, e.second.serializer);
+      os << ' ';
+      if (e.second.name)
+        os << e.second.name;
+      else
+        os << "field_" << std::dec << e.first;
+
+      os << " = " << e.first << ";" << std::endl;
+    }
+    os << '}' << std::endl << std::endl;
+  }
+}

--- a/src/leapserial/test/CMakeLists.txt
+++ b/src/leapserial/test/CMakeLists.txt
@@ -60,6 +60,7 @@ add_conditional_sources(
   GROUP_NAME "Protobuf"
   FILES
   ArchiveProtobufTest.cpp
+  SchemaTest.cpp
   TestProtobuf.proto
   TestProtobuf.pb.h
   TestProtobuf.pb.cc

--- a/src/leapserial/test/SchemaTest.cpp
+++ b/src/leapserial/test/SchemaTest.cpp
@@ -1,0 +1,86 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "LeapSerial.h"
+#include "TestProtobufLS.hpp"
+#include <gtest/gtest.h>
+#include <google/protobuf/compiler/importer.h>
+#include <google/protobuf/io/zero_copy_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <array>
+#include <iomanip>
+#include <sstream>
+
+namespace io = google::protobuf::io;
+namespace cl = google::protobuf::compiler;
+
+class CountsErrors :
+  public cl::MultiFileErrorCollector
+{
+public:
+  struct Bad {
+    std::string filename;
+    int line;
+    int column;
+    std::string message;
+  };
+
+  std::vector<Bad> badness;
+
+  void AddError(const std::string& filename, int line, int column, const std::string& message) override {
+    badness.push_back({ filename, line, column, message });
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const CountsErrors& rhs) {
+    for (auto& bad : rhs.badness)
+      os << bad.filename << ":" << bad.line << ':' << bad.column << ": " << bad.message << std::endl;
+    return os;
+  }
+};
+
+class MemorySourceTree :
+  public cl::SourceTree
+{
+public:
+  MemorySourceTree(const std::initializer_list<std::pair<const std::string, std::string>>& entries) :
+    files(entries)
+  {}
+
+  std::unordered_map<std::string, std::string> files;
+
+  io::ZeroCopyInputStream* Open(const std::string& filename) override {
+    auto q = files.find(filename);
+    if (q == files.end())
+      return nullptr;
+    return new io::ArrayInputStream{ q->second.data(), (int) q->second.length() };
+  }
+};
+
+TEST(SchemaTest, BasicDescriptorSerialization) {
+  std::stringstream ss;
+
+  // This step is the only step that's required to dump a full schema in proto1
+  // format.  The rest of this function is just to parse it
+  leap::Serialize<leap::protobuf_v1>(ss, Person::GetDescriptor());
+  
+  // Now we have to parse the protobuf file
+  const google::protobuf::FileDescriptor* fd;
+  CountsErrors error_collector;
+  MemorySourceTree mst{
+    { "root.proto", ss.str() }
+  };
+
+  // Importer utility class does most of the work for us, we just need to tell it
+  // how to find files and where to report issues
+  cl::Importer imp{ &mst, &error_collector };
+  fd = imp.Import("root.proto");
+  ASSERT_NE(nullptr, fd) << error_collector;
+
+  // This part verifies that the regenerated schema is correct.
+  auto personDesc = fd->FindMessageTypeByName("Person");
+  ASSERT_NE(nullptr, personDesc) << "Failed to find person message in schema";
+  ASSERT_NE(nullptr, personDesc->FindFieldByName("name"));
+  ASSERT_NE(nullptr, personDesc->FindFieldByName("id"));
+  ASSERT_NE(nullptr, personDesc->FindFieldByName("email"));
+  ASSERT_NE(nullptr, personDesc->FindFieldByName("phone"));
+  ASSERT_NE(nullptr, personDesc->FindFieldByName("pets"));
+}

--- a/src/leapserial/test/TestProtobuf.proto
+++ b/src/leapserial/test/TestProtobuf.proto
@@ -10,7 +10,7 @@ message Pet {
   required Species species = 2;
 }
 
-message PetFieldEntry{
+message PetFieldEntry {
   required string key = 1;
   required Pet value = 2;
 }
@@ -38,3 +38,4 @@ message Person {
 message AddressBook {
   repeated Person person = 1;
 }
+

--- a/src/leapserial/test/TestProtobufLS.hpp
+++ b/src/leapserial/test/TestProtobufLS.hpp
@@ -40,8 +40,11 @@ namespace {
 
     static leap::descriptor GetDescriptor(void) {
       return{
-        { 1, &Pet::name },
-        { 2, &Pet::species }
+        "Pet",
+        {
+          { 1, &Pet::name },
+          { 2, &Pet::species }
+        }
       };
     }
   };
@@ -64,11 +67,14 @@ namespace {
 
     static leap::descriptor GetDescriptor(void) {
       return{
-        { 1, &Person::name },
-        { 2, &Person::id },
-        { 3, &Person::email },
-        { 4, &Person::phone },
-        { 5, &Person::pets }
+        "Person",
+        {
+          { 1, "name", &Person::name },
+          { 2, "id", &Person::id },
+          { 3, "email", &Person::email },
+          { 4, "phone", &Person::phone },
+          { 5, "pets", &Person::pets }
+        }
       };
     }
   };


### PR DESCRIPTION
This allows LeapSerial descriptors to be written out as a .proto file to make it possible to compile deserializers in other languages using Google protoc.