### PR TITLE
Add explicit option to disable protobuf tests

### DIFF
--- a/src/leapserial/test/CMakeLists.txt
+++ b/src/leapserial/test/CMakeLists.txt
@@ -36,10 +36,14 @@ add_conditional_sources(
   TestObject_generated.h
 )
 
-if(LS_PROTOBUF_REQUIRED)
-  find_package(Protobuf 2.5.0 REQUIRED)
-else()
-  find_package(Protobuf 2.5.0 QUIET)
+option(LS_ENABLE_PROTOBUF_TESTS "Enable protobuf tests" ON)
+option(LS_PROTOBUF_REQUIRED "Require protobuf tests" OFF)
+if(LS_ENABLE_PROTOBUF_TESTS OR LS_PROTOBUF_REQUIRED)
+  if(LS_PROTOBUF_REQUIRED)
+    find_package(Protobuf 2.5.0 REQUIRED)
+  else()
+    find_package(Protobuf 2.5.0 QUIET)
+  endif()
 endif()
 
 if(Protobuf_FOUND)


### PR DESCRIPTION
This is required because these tests will not run correctly in certain cross-compiled environments due to defects in the way that FindProtobuf works in those cases.