### PR TITLE
Provide more useful static assertions when performing descriptor instantiation

### DIFF
--- a/LeapSerial/field_descriptor.h
+++ b/LeapSerial/field_descriptor.h
@@ -135,6 +135,10 @@ namespace leap {
       offset(reinterpret_cast<size_t>(&(static_cast<T*>(nullptr)->*val))),
       serializer(field_serializer_t<U, void>::GetDescriptor())
     {
+      // Verify that we can actually serialize T--the fact that we have a descriptor does not necessarily imply this
+      // If a problem is being encountered here, verify that the type in question is actually serializable
+      static_assert(!std::is_base_of<std::false_type, serial_traits<T>>::value, "Descriptor contains an entry that is not serializable");
+
       // Instantiate serial_traits on the type object itself.  If T::GetDescriptor is provided,
       // this has the effect of ultimately instantiating descriptor_entry_t<T>
       (void)&serial_traits<T>::type;

--- a/src/leapserial/test/MapTest.cpp
+++ b/src/leapserial/test/MapTest.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <type_traits>
 
+static_assert(leap::has_serializer<int>::value, "Single primitive");
 static_assert(leap::has_serializer<std::map<int, int>>::value, "Map of primitives");
 static_assert(leap::has_serializer<std::map<std::string, std::string>>::value, "Map of nonprimitives");
 static_assert(leap::has_serializer<std::unordered_map<int, int>>::value, "Unordered map of primitives");

--- a/src/leapserial/test/SerializationTest.cpp
+++ b/src/leapserial/test/SerializationTest.cpp
@@ -22,6 +22,7 @@ static_assert(!leap::has_serializer<DummyStruct>::value, "A dummy structure was 
 static_assert(!leap::has_serializer<DummyStruct[2]>::value, "An arry of dummy structures was incorrectly classified as having a valid serializer");
 static_assert(!leap::has_serializer<std::vector<DummyStruct>>::value, "A vector of dummy structures was incorrectly classified as having a valid serializer");
 static_assert(!leap::has_serializer<std::vector<DummyStruct>>::value, "A vector of DummyStruct was incorrectly classified as having a valid serializer");
+static_assert(!leap::has_serializer<std::unique_ptr<DummyStruct>>::value, "A vector of DummyStruct was incorrectly classified as having a valid serializer");
 
 struct MyRepeatedStructure {
   int* pv;


### PR DESCRIPTION
We should probably allow pattern matching in all `primitive_serial_traits` types and simply change the inheritance to indicate whether the matched type is valid or not.  We only throw a hard error if a user attempts to instantiate one of the static methods in the type, which would imply an attempt to use rather than a simple query on the availability of a serializer.

- [ ] Verify this does not introduce downstream breaks