### PR TITLE
Eliminate incorrect static assert

### DIFF
--- a/LeapSerial/field_descriptor.h
+++ b/LeapSerial/field_descriptor.h
@@ -135,12 +135,10 @@ namespace leap {
       offset(reinterpret_cast<size_t>(&(static_cast<T*>(nullptr)->*val))),
       serializer(field_serializer_t<U, void>::GetDescriptor())
     {
-      // Verify that we can actually serialize T--the fact that we have a descriptor does not necessarily imply this
-      // If a problem is being encountered here, verify that the type in question is actually serializable
-      static_assert(!std::is_base_of<std::false_type, serial_traits<T>>::value, "Descriptor contains an entry that is not serializable");
-
       // Instantiate serial_traits on the type object itself.  If T::GetDescriptor is provided,
-      // this has the effect of ultimately instantiating descriptor_entry_t<T>
+      // this has the effect of ultimately instantiating descriptor_entry_t<T>.  Sometimes, though,
+      // this member is not provided--for instance, when a descriptor includes a member of a base
+      // type and that base type is not itself serializable.
       (void)&serial_traits<T>::type;
       static_assert(has_serializer<U>::value, "An attempt was made to serialize type U, which does not provide a serial_traits entry or GetDescriptor function");
     }


### PR DESCRIPTION
Turns out that sometimes a serialization descriptor can contain fields from a base type, which means it's possible for a `field_descriptor` to be instantiated on a non-serializable type.  Eliminate the static assertion so we can still compile.