### PR TITLE
Populate reflection with function pointers rather than raw descriptors

### DIFF
--- a/LeapSerial/descriptors.h
+++ b/LeapSerial/descriptors.h
@@ -12,11 +12,11 @@ namespace leap {
   // Common base type for linkage
   struct descriptor_entry
   {
-    descriptor_entry(const std::type_info& ti, const descriptor& desc);
+    descriptor_entry(const std::type_info& ti, const descriptor& (*pfnDesc)());
 
     const descriptor_entry* const Next;
     const std::type_info& ti;
-    const descriptor& desc;
+    const descriptor& (*pfnDesc)();
   };
 
   // Entry generator type
@@ -31,7 +31,7 @@ namespace leap {
     );
 
     descriptor_entry_t(void) :
-      descriptor_entry{ typeid(T), serial_traits<T>::get_descriptor() }
+      descriptor_entry{ typeid(T), &serial_traits<T>::get_descriptor }
     {}
 
     static const descriptor_entry_t s_init;

--- a/LeapSerial/field_serializer_t.h
+++ b/LeapSerial/field_serializer_t.h
@@ -135,8 +135,8 @@ namespace leap {
       static std::unordered_set<field_serializer_t, mem_hash<field_serializer_t>> st;
       static std::mutex lock;
 
+      field_serializer_t key{ pfn };
       std::lock_guard<std::mutex> lk(lock);
-      field_serializer_t key{pfn};
       auto q = st.find(key);
       if (q == st.end())
         q = st.insert(q, key);
@@ -199,8 +199,8 @@ namespace leap {
       static std::unordered_set<field_serializer_t, mem_hash<field_serializer_t>> st;
       static std::mutex lock;
 
+      field_serializer_t key{ getter, setter };
       std::lock_guard<std::mutex> lk(lock);
-      field_serializer_t key{getter, setter};
       auto q = st.find(key);
       if (q == st.end())
         q = st.insert(q, key);
@@ -263,8 +263,8 @@ namespace leap {
       static std::unordered_set<field_serializer_t, mem_hash<field_serializer_t>> st;
       static std::mutex lock;
  
-      std::lock_guard<std::mutex> lk(lock);
       field_serializer_t key{ getter, setter };
+      std::lock_guard<std::mutex> lk(lock);
       auto q = st.find(key);
       if (q == st.end())
         q = st.insert(q, key);

--- a/src/leapserial/descriptors.cpp
+++ b/src/leapserial/descriptors.cpp
@@ -5,10 +5,10 @@
 
 using namespace leap;
 
-descriptor_entry::descriptor_entry(const std::type_info& ti, const descriptor& desc) :
+descriptor_entry::descriptor_entry(const std::type_info& ti, const descriptor& (*pfnDesc)()) :
   Next(descriptors::Link(*this)),
   ti(ti),
-  desc(desc)
+  pfnDesc(pfnDesc)
 {}
 
 const descriptor_entry* descriptors::s_pHead = nullptr;


### PR DESCRIPTION
Need to do this because it's not always safe to actually perform descriptor initialization at init/load time, particularly on Windows where the loader lock may be held.

- [x] Fixes #40