### PR TITLE
Fix stream read behavior

### DIFF
--- a/src/leapserial/Archive.cpp
+++ b/src/leapserial/Archive.cpp
@@ -11,12 +11,16 @@ bool InputStreamAdapter::IsEof(void) const {
 
 std::streamsize InputStreamAdapter::Read(void* pBuf, std::streamsize ncb) {
   is.read((char*)pBuf, ncb);
-  return is ? is.gcount() : -1;
+  if (is.fail() && !is.eof())
+      return -1;
+  return is.gcount();
 }
 
 std::streamsize InputStreamAdapter::Skip(std::streamsize ncb) {
   is.ignore(ncb);
-  return is ? is.gcount() : -1;
+  if (is.fail() && !is.eof())
+    return -1;
+  return is.gcount();
 }
 
 bool OutputStreamAdapter::Write(const void* pBuf, std::streamsize ncb) {


### PR DESCRIPTION
Attempting to read past the end of the stream is not an error, and should not swallow the number of bytes read.  Only return an error value if an error condition has actually been encountered.