### PR TITLE
Move input stream adapter to its own header

### DIFF
--- a/LeapSerial/Archive.h
+++ b/LeapSerial/Archive.h
@@ -4,6 +4,7 @@
 #include "IDictionary.h"
 #include "IInputStream.h"
 #include "IOutputStream.h"
+#include "StreamAdapter.h"
 #include <cstdint>
 #include <functional>
 #include <ios>
@@ -38,50 +39,6 @@ namespace leap {
       T prior;
     };
   }
-
-  /// <summary>
-  /// Mapping adaptor, allows input streams to be wrapped to support Archive operations
-  /// </summary>
-  class InputStreamAdapter:
-    public IInputStream
-  {
-  public:
-    InputStreamAdapter(std::istream& is) :
-      is(is)
-    {}
-
-    InputStreamAdapter(const InputStreamAdapter& rhs) :
-      is(rhs.is)
-    {}
-
-  private:
-    std::istream& is;
-
-  public:
-    // IInputStream overrides:
-    bool IsEof(void) const override;
-    std::streamsize Read(void* pBuf, std::streamsize ncb) override;
-    std::streamsize Skip(std::streamsize ncb) override;
-  };
-
-  class OutputStreamAdapter:
-    public IOutputStream
-  {
-  public:
-    OutputStreamAdapter(std::ostream& os) :
-      os(os)
-    {}
-
-    OutputStreamAdapter(const OutputStreamAdapter& rhs) :
-      os(rhs.os)
-    {}
-
-    // IOutputStream overrides:
-    bool Write(const void* pBuf, std::streamsize ncb) override;
-
-  private:
-    std::ostream& os;
-  };
 
   /// <summary>
   /// An enumeration of the different basic types that are handled directly by the archiver

--- a/LeapSerial/IInputStream.h
+++ b/LeapSerial/IInputStream.h
@@ -32,4 +32,3 @@ namespace leap {
     virtual std::streamsize Skip(std::streamsize ncb) = 0;
   };
 }
-

--- a/LeapSerial/StreamAdapter.h
+++ b/LeapSerial/StreamAdapter.h
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "IInputStream.h"
 #include "IOutputStream.h"

--- a/LeapSerial/StreamAdapter.h
+++ b/LeapSerial/StreamAdapter.h
@@ -13,17 +13,9 @@ namespace leap {
     public IInputStream
   {
   public:
-    InputStreamAdapter(std::istream& is) :
-      is(is)
-    {}
-    InputStreamAdapter(std::unique_ptr<std::istream> pis) :
-      is(*pis),
-      pis(std::move(pis))
-    {}
-
-    InputStreamAdapter(const InputStreamAdapter& rhs) :
-      is(rhs.is)
-    {}
+    InputStreamAdapter(std::istream& is);
+    InputStreamAdapter(std::unique_ptr<std::istream> pis);
+    InputStreamAdapter(const InputStreamAdapter& rhs);
 
     ~InputStreamAdapter(void);
 
@@ -50,19 +42,9 @@ namespace leap {
     public IOutputStream
   {
   public:
-    OutputStreamAdapter(std::ostream& os) :
-      os(os)
-    {}
-
-    OutputStreamAdapter(std::unique_ptr<std::ostream> pos) :
-      os(*pos),
-      pos(std::move(pos))
-    {}
-
-    OutputStreamAdapter(const OutputStreamAdapter& rhs) :
-      os(rhs.os)
-    {}
-
+    OutputStreamAdapter(std::ostream& os);
+    OutputStreamAdapter(std::unique_ptr<std::ostream> pos);
+    OutputStreamAdapter(const OutputStreamAdapter& rhs);
     ~OutputStreamAdapter(void);
 
     // IOutputStream overrides:

--- a/LeapSerial/StreamAdapter.h
+++ b/LeapSerial/StreamAdapter.h
@@ -25,6 +25,8 @@ namespace leap {
       is(rhs.is)
     {}
 
+    ~InputStreamAdapter(void);
+
   private:
     std::istream& is;
 
@@ -60,6 +62,8 @@ namespace leap {
     OutputStreamAdapter(const OutputStreamAdapter& rhs) :
       os(rhs.os)
     {}
+
+    ~OutputStreamAdapter(void);
 
     // IOutputStream overrides:
     bool Write(const void* pBuf, std::streamsize ncb) override;

--- a/LeapSerial/StreamAdapter.h
+++ b/LeapSerial/StreamAdapter.h
@@ -1,0 +1,72 @@
+#pragma once
+#include "IInputStream.h"
+#include "IOutputStream.h"
+#include <iosfwd>
+#include <memory>
+
+namespace leap {
+  /// <summary>
+  /// Mapping adaptor, allows input streams to be wrapped to support Archive operations
+  /// </summary>
+  class InputStreamAdapter :
+    public IInputStream
+  {
+  public:
+    InputStreamAdapter(std::istream& is) :
+      is(is)
+    {}
+    InputStreamAdapter(std::unique_ptr<std::istream> pis) :
+      is(*pis),
+      pis(std::move(pis))
+    {}
+
+    InputStreamAdapter(const InputStreamAdapter& rhs) :
+      is(rhs.is)
+    {}
+
+  private:
+    std::istream& is;
+
+    // Non-null if we have taken ownership
+    const std::unique_ptr<std::istream> pis;
+
+  public:
+    // IInputStream overrides:
+    bool IsEof(void) const override;
+    std::streamsize Read(void* pBuf, std::streamsize ncb) override;
+    std::streamsize Skip(std::streamsize ncb) override;
+
+    /// <summary>
+    /// Sets the offset on the underlying input stream
+    /// </summary>
+    /// <returns>this</returns>
+    InputStreamAdapter* Seek(std::streamsize off);
+  };
+
+  class OutputStreamAdapter :
+    public IOutputStream
+  {
+  public:
+    OutputStreamAdapter(std::ostream& os) :
+      os(os)
+    {}
+
+    OutputStreamAdapter(std::unique_ptr<std::ostream> pos) :
+      os(*pos),
+      pos(std::move(pos))
+    {}
+
+    OutputStreamAdapter(const OutputStreamAdapter& rhs) :
+      os(rhs.os)
+    {}
+
+    // IOutputStream overrides:
+    bool Write(const void* pBuf, std::streamsize ncb) override;
+
+  private:
+    std::ostream& os;
+
+    // Non-null if we have taken ownership
+    const std::unique_ptr<std::ostream> pos;
+  };
+}

--- a/src/leapserial/Archive.cpp
+++ b/src/leapserial/Archive.cpp
@@ -5,28 +5,6 @@
 
 using namespace leap;
 
-bool InputStreamAdapter::IsEof(void) const {
-  return is.eof();
-}
-
-std::streamsize InputStreamAdapter::Read(void* pBuf, std::streamsize ncb) {
-  is.read((char*)pBuf, ncb);
-  if (is.fail() && !is.eof())
-      return -1;
-  return is.gcount();
-}
-
-std::streamsize InputStreamAdapter::Skip(std::streamsize ncb) {
-  is.ignore(ncb);
-  if (is.fail() && !is.eof())
-    return -1;
-  return is.gcount();
-}
-
-bool OutputStreamAdapter::Write(const void* pBuf, std::streamsize ncb) {
-  return (bool)os.write((const char*)pBuf, ncb);
-}
-
 const char* leap::ToString(serial_atom atom) {
   switch (atom) {
   case serial_atom::ignored:

--- a/src/leapserial/CMakeLists.txt
+++ b/src/leapserial/CMakeLists.txt
@@ -42,6 +42,8 @@ set(LeapSerial_SRCS
   serial_traits.h
   serialization_error.h
   serialization_error.cpp
+  StreamAdapter.h
+  StreamAdapter.cpp
   Utility.hpp
   Utility.cpp
 )

--- a/src/leapserial/StreamAdapter.cpp
+++ b/src/leapserial/StreamAdapter.cpp
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "StreamAdapter.h"
 

--- a/src/leapserial/StreamAdapter.cpp
+++ b/src/leapserial/StreamAdapter.cpp
@@ -5,6 +5,19 @@
 
 using namespace leap;
 
+InputStreamAdapter::InputStreamAdapter(std::istream& is) :
+  is(is)
+{}
+
+InputStreamAdapter::InputStreamAdapter(std::unique_ptr<std::istream> pis) :
+  is(*pis),
+  pis(std::move(pis))
+{}
+
+InputStreamAdapter::InputStreamAdapter(const InputStreamAdapter& rhs) :
+  is(rhs.is)
+{}
+
 bool InputStreamAdapter::IsEof(void) const {
   return is.eof();
 }
@@ -29,6 +42,19 @@ InputStreamAdapter* InputStreamAdapter::Seek(std::streamsize off) {
   is.seekg(off, std::ios::beg);
   return this;
 }
+
+OutputStreamAdapter::OutputStreamAdapter(std::ostream& os) :
+  os(os)
+{}
+
+OutputStreamAdapter::OutputStreamAdapter(std::unique_ptr<std::ostream> pos) :
+  os(*pos),
+  pos(std::move(pos))
+{}
+
+OutputStreamAdapter::OutputStreamAdapter(const OutputStreamAdapter& rhs) :
+  os(rhs.os)
+{}
 
 OutputStreamAdapter::~OutputStreamAdapter(void) {}
 

--- a/src/leapserial/StreamAdapter.cpp
+++ b/src/leapserial/StreamAdapter.cpp
@@ -1,12 +1,15 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "StreamAdapter.h"
+#include <iostream>
 
 using namespace leap;
 
 bool InputStreamAdapter::IsEof(void) const {
   return is.eof();
 }
+
+InputStreamAdapter::~InputStreamAdapter(void) {}
 
 std::streamsize InputStreamAdapter::Read(void* pBuf, std::streamsize ncb) {
   is.read((char*)pBuf, ncb);
@@ -26,6 +29,8 @@ InputStreamAdapter* InputStreamAdapter::Seek(std::streamsize off) {
   is.seekg(off, std::ios::beg);
   return this;
 }
+
+OutputStreamAdapter::~OutputStreamAdapter(void) {}
 
 bool OutputStreamAdapter::Write(const void* pBuf, std::streamsize ncb) {
   return (bool)os.write((const char*)pBuf, ncb);

--- a/src/leapserial/StreamAdapter.cpp
+++ b/src/leapserial/StreamAdapter.cpp
@@ -1,0 +1,31 @@
+#include "stdafx.h"
+#include "StreamAdapter.h"
+
+using namespace leap;
+
+bool InputStreamAdapter::IsEof(void) const {
+  return is.eof();
+}
+
+std::streamsize InputStreamAdapter::Read(void* pBuf, std::streamsize ncb) {
+  is.read((char*)pBuf, ncb);
+  if (is.fail() && !is.eof())
+    return -1;
+  return is.gcount();
+}
+
+std::streamsize InputStreamAdapter::Skip(std::streamsize ncb) {
+  is.ignore(ncb);
+  if (is.fail() && !is.eof())
+    return -1;
+  return is.gcount();
+}
+
+InputStreamAdapter* InputStreamAdapter::Seek(std::streamsize off) {
+  is.seekg(off, std::ios::beg);
+  return this;
+}
+
+bool OutputStreamAdapter::Write(const void* pBuf, std::streamsize ncb) {
+  return (bool)os.write((const char*)pBuf, ncb);
+}


### PR DESCRIPTION
Other input stream types are isolated to their own headers, this one should be as well.