### PR TITLE
Adapter streams should take ownership of their underlying fields

### DIFF
--- a/LeapSerial/AESStream.h
+++ b/LeapSerial/AESStream.h
@@ -36,7 +36,7 @@ namespace leap {
     /// <summary>
     /// Initializes the encryption stream
     /// </summary>
-    AESEncryptionStream(IOutputStream& os, const std::array<uint8_t, 32>& key);
+    AESEncryptionStream(std::unique_ptr<IOutputStream>&& os, const std::array<uint8_t, 32>& key);
 
   protected:
     // OutputFilterStreamBase overrides:
@@ -51,7 +51,7 @@ namespace leap {
     public AES256Base
   {
   public:
-    AESDecryptionStream(IInputStream& is, const std::array<uint8_t, 32>& key);
+    AESDecryptionStream(std::unique_ptr<IInputStream>&& is, const std::array<uint8_t, 32>& key);
 
   protected:
     // InputFilterStreamBase overrides:

--- a/LeapSerial/CompressionStream.h
+++ b/LeapSerial/CompressionStream.h
@@ -30,7 +30,7 @@ namespace leap {
     /// <summary>
     /// Initializes the decompression stream
     /// </summary>
-    explicit DecompressionStream(IInputStream& is);
+    explicit DecompressionStream(std::unique_ptr<IInputStream>&& is);
 
   protected:
     // InputFilterStreamBase overrides:
@@ -50,7 +50,7 @@ namespace leap {
     /// </summary>
     /// <param name="os">The underlying stream</param>
     /// <param name="level">The compression level, a value in the range 0 to 9.  Set to -1 to use the default.</param>
-    explicit CompressionStream(IOutputStream& os, int level = -1);
+    explicit CompressionStream(std::unique_ptr<IOutputStream>&& os, int level = -1);
 
     ~CompressionStream(void);
 

--- a/LeapSerial/FilterStreamBase.h
+++ b/LeapSerial/FilterStreamBase.h
@@ -16,10 +16,10 @@ namespace leap {
     public IInputStream
   {
   public:
-    explicit InputFilterStreamBase(IInputStream& is);
+    explicit InputFilterStreamBase(std::unique_ptr<IInputStream>&& is);
 
   private:
-    IInputStream& is;
+    const std::unique_ptr<IInputStream> is;
 
     // Fail flag
     bool fail = false;
@@ -54,13 +54,13 @@ namespace leap {
     public IOutputStream
   {
   public:
-    explicit OutputFilterStreamBase(IOutputStream& os);
+    explicit OutputFilterStreamBase(std::unique_ptr<IOutputStream>&& os);
 
     ~OutputFilterStreamBase(void);
 
   private:
     // Base output stream, where our data goes
-    IOutputStream& os;
+    const std::unique_ptr<IOutputStream> os;
 
     // Output buffer used as scratch space
     std::vector<uint8_t> buffer;

--- a/LeapSerial/LeapSerial.h
+++ b/LeapSerial/LeapSerial.h
@@ -99,4 +99,10 @@ namespace leap {
   void Serialize(stream_t&& os, const T& obj) {
     Serialize<OArchiveImpl, stream_t, T>(std::forward<stream_t&&>(os), obj);
   }
+
+  // Utility method until everyone moves to C++14
+  template<typename T, typename... Args>
+  std::unique_ptr<T> make_unique(Args&&... args) {
+    return std::unique_ptr<T>{new T{ std::forward<Args&&>(args)... }};
+  }
 }

--- a/src/leapserial/AESStream.cpp
+++ b/src/leapserial/AESStream.cpp
@@ -22,8 +22,8 @@ void AES256Base::NextBlock(void) {
   blockByte = 0;
 }
 
-AESDecryptionStream::AESDecryptionStream(IInputStream& is, const std::array<uint8_t, 32>& key) :
-  InputFilterStreamBase(is),
+AESDecryptionStream::AESDecryptionStream(std::unique_ptr<IInputStream>&& is, const std::array<uint8_t, 32>& key) :
+  InputFilterStreamBase(std::move(is)),
   AES256Base(key)
 {}
 
@@ -47,8 +47,8 @@ bool AESDecryptionStream::Transform(const void* input, size_t& ncbIn, void* outp
   return true;
 }
 
-AESEncryptionStream::AESEncryptionStream(IOutputStream& os, const std::array<uint8_t, 32>& key) :
-  OutputFilterStreamBase(os),
+AESEncryptionStream::AESEncryptionStream(std::unique_ptr<IOutputStream>&& os, const std::array<uint8_t, 32>& key) :
+  OutputFilterStreamBase(std::move(os)),
   AES256Base(key)
 {}
 

--- a/src/leapserial/CompressionStream.cpp
+++ b/src/leapserial/CompressionStream.cpp
@@ -24,8 +24,8 @@ ZStreamBase::~ZStreamBase(void) {
     deflateEnd(strm.get());
 }
 
-DecompressionStream::DecompressionStream(IInputStream& is) :
-  InputFilterStreamBase(is)
+DecompressionStream::DecompressionStream(std::unique_ptr<IInputStream>&& is) :
+  InputFilterStreamBase(std::move(is))
 {
   inflateInit(strm.get());
   strm->avail_in = 0;
@@ -47,8 +47,8 @@ bool DecompressionStream::Transform(const void* input, size_t& ncbIn, void* outp
   return true;
 }
 
-CompressionStream::CompressionStream(IOutputStream& os, int level) :
-  OutputFilterStreamBase(os)
+CompressionStream::CompressionStream(std::unique_ptr<IOutputStream>&& os, int level) :
+  OutputFilterStreamBase(std::move(os))
 {
   if (level < -1 || 9 < level)
     throw std::invalid_argument("Compression stream level must be in the range [0, 9]");

--- a/src/leapserial/test/AESStreamTest.cpp
+++ b/src/leapserial/test/AESStreamTest.cpp
@@ -41,15 +41,19 @@ TEST_F(AESStreamTest, KnownValueRoundTrip) {
   std::stringstream ss;
 
   {
-    leap::OutputStreamAdapter osa(ss);
-    leap::AESEncryptionStream cs(osa, sc_key);
+    leap::AESEncryptionStream cs(
+      leap::make_unique<leap::OutputStreamAdapter>(ss),
+      sc_key
+    );
     cs.Write(vec.data(), vec.size());
   }
 
   ss.seekg(0);
 
-  leap::InputStreamAdapter isa{ ss };
-  leap::AESDecryptionStream ds{ isa, sc_key };
+  leap::AESDecryptionStream ds{
+    leap::make_unique<leap::InputStreamAdapter>(ss),
+    sc_key
+  };
 
   std::vector<uint8_t> read(vec.size());
   ASSERT_EQ(vec.size(), ds.Read(read.data(), read.size())) << "Did not read expected number of bytes";
@@ -60,8 +64,10 @@ TEST_F(AESStreamTest, ExactSizeCheck) {
   std::vector<uint8_t> vec(45, 0);
 
   std::stringstream ss;
-  leap::OutputStreamAdapter osa(ss);
-  leap::AESEncryptionStream cs(osa, sc_key);
+  leap::AESEncryptionStream cs(
+    leap::make_unique<leap::OutputStreamAdapter>(ss),
+    sc_key
+  );
   cs.Write(vec.data(), vec.size());
 
   std::string str = ss.str();
@@ -73,15 +79,19 @@ TEST_F(AESStreamTest, RoundTrip) {
 
   std::stringstream ss;
   {
-    leap::OutputStreamAdapter osa{ ss };
-    leap::AESEncryptionStream cs{ osa, sc_key };
+    leap::AESEncryptionStream cs{
+      leap::make_unique<leap::OutputStreamAdapter>(ss),
+      sc_key
+    };
     leap::Serialize(cs, val);
   }
   SimpleStruct reacq;
 
   {
-    leap::InputStreamAdapter isa{ ss };
-    leap::AESDecryptionStream ds{ isa, sc_key };
+    leap::AESDecryptionStream ds{
+      leap::make_unique<leap::InputStreamAdapter>(ss),
+      sc_key
+    };
     leap::Deserialize(ds, reacq);
   }
 

--- a/src/leapserial/test/CompressionStreamTest.cpp
+++ b/src/leapserial/test/CompressionStreamTest.cpp
@@ -39,15 +39,17 @@ TEST_F(CompressionStreamTest, KnownValueRoundTrip) {
   std::stringstream ss;
 
   {
-    leap::OutputStreamAdapter osa(ss);
-    leap::CompressionStream cs(osa);
+    leap::CompressionStream cs(
+      leap::make_unique<leap::OutputStreamAdapter>(ss)
+    );
     cs.Write(vec.data(), vec.size());
   }
 
   ss.seekg(0);
 
-  leap::InputStreamAdapter isa{ ss };
-  leap::DecompressionStream ds{ isa };
+  leap::DecompressionStream ds{
+    leap::make_unique<leap::InputStreamAdapter>(ss)
+  };
 
   std::vector<uint8_t> read(vec.size());
   ASSERT_EQ(vec.size(), ds.Read(read.data(), read.size())) << "Did not read expected number of bytes";
@@ -59,8 +61,10 @@ TEST_F(CompressionStreamTest, CompressionPropCheck) {
 
   std::stringstream ss;
   {
-    leap::OutputStreamAdapter osa{ ss };
-    leap::CompressionStream cs{ osa, 9 };
+    leap::CompressionStream cs{
+      leap::make_unique<leap::OutputStreamAdapter>(ss),
+      9
+    };
     leap::Serialize(cs, val);
   }
 
@@ -73,15 +77,17 @@ TEST_F(CompressionStreamTest, RoundTrip) {
 
   std::stringstream ss;
   {
-    leap::OutputStreamAdapter osa{ ss };
-    leap::CompressionStream cs{ osa };
+    leap::CompressionStream cs{
+      leap::make_unique<leap::OutputStreamAdapter>(ss)
+    };
     leap::Serialize(cs, val);
   }
 
   SimpleStruct reacq;
   {
-    leap::InputStreamAdapter isa{ ss };
-    leap::DecompressionStream ds{ isa };
+    leap::DecompressionStream ds{
+      leap::make_unique<leap::InputStreamAdapter>(ss)
+    };
     leap::Deserialize(ds, reacq);
   }
 
@@ -94,8 +100,9 @@ TEST_F(CompressionStreamTest, TruncatedStreamTest) {
   std::string str;
   {
     std::stringstream ss;
-    leap::OutputStreamAdapter osa{ ss };
-    leap::CompressionStream cs{ osa };
+    leap::CompressionStream cs{
+      leap::make_unique<leap::OutputStreamAdapter>(ss)
+    };
     leap::Serialize(cs, val);
     str = ss.str();
   }
@@ -107,8 +114,9 @@ TEST_F(CompressionStreamTest, TruncatedStreamTest) {
   SimpleStruct reacq;
   {
     std::stringstream ss(std::move(str));
-    leap::InputStreamAdapter isa{ ss };
-    leap::DecompressionStream ds{ isa };
+    leap::DecompressionStream ds{
+      leap::make_unique<leap::InputStreamAdapter>(ss)
+    };
     ASSERT_ANY_THROW(leap::Deserialize(ds, reacq));
   }
 }


### PR DESCRIPTION
This is necessary to allow a single stream to completely wrap the interior stream.  Otherwise, we wind up with memory management issues everywhere.  Furthermore, there should really be a concept of exclusive ownership, here--if someone attempted to directly access the underlying stream, we could possibly wind up with a state inconsistency that would be tough to resolve in the general case.