### PR TITLE
Fix premature EOF check behavior

### DIFF
--- a/src/leapserial/IArchiveImpl.cpp
+++ b/src/leapserial/IArchiveImpl.cpp
@@ -209,7 +209,8 @@ bool IArchiveImpl::IsReleased(uint32_t objId) {
 }
 
 void IArchiveImpl::ReadByteArray(void* pBuf, uint64_t ncb) {
-  if(is.Read(pBuf, ncb) < 0)
+  std::streamsize nRead = is.Read(pBuf, ncb);
+  if(nRead != ncb)
     throw std::runtime_error("End of file reached prematurely");
   m_count += ncb;
 }


### PR DESCRIPTION
Caused by not actually verifying that we read the number of bytes we requested that we read.