### PR TITLE
Add buffered stream "initially valid" feature

### DIFF
--- a/LeapSerial/BufferedStream.h
+++ b/LeapSerial/BufferedStream.h
@@ -9,7 +9,14 @@ namespace leap {
     public leap::IOutputStream
   {
   public:
-    BufferedStream(void* buffer, size_t ncbBuffer);
+    /// <summary>Constructor for a stream built on a fixed-size underlying buffer</summary>
+    /// <param name="buffer">The underlying buffer itself</param>
+    /// <param name="ncbBuffer">The size of the buffer</param>
+    /// <param name="ncbInitialValid">
+    /// Counts the number of bytes from the beginning of the stream that may be read immediately
+    /// after construction of this type
+    /// </param>
+    BufferedStream(void* buffer, size_t ncbBuffer, size_t ncbInitialValid = 0);
 
   private:
     // The buffered data proper
@@ -20,7 +27,7 @@ namespace leap {
     size_t m_readOffset = 0;
 
     // A pointer to our WRITE offset in the buffer
-    size_t m_writeOffset = 0;
+    size_t m_writeOffset;
 
   public:
     bool Write(const void* pBuf, std::streamsize ncb) override;

--- a/src/leapserial/BufferedStream.cpp
+++ b/src/leapserial/BufferedStream.cpp
@@ -6,9 +6,10 @@
 
 using namespace leap;
 
-BufferedStream::BufferedStream(void* buffer, size_t ncbBuffer) :
+BufferedStream::BufferedStream(void* buffer, size_t ncbBuffer, size_t ncbInitialValid) :
   buffer(buffer),
-  ncbBuffer(ncbBuffer)
+  ncbBuffer(ncbBuffer),
+  m_writeOffset(ncbInitialValid)
 {}
 
 

--- a/src/leapserial/test/BufferedStreamTest.cpp
+++ b/src/leapserial/test/BufferedStreamTest.cpp
@@ -21,3 +21,12 @@ TEST_F(BufferedStreamTest, WriteAndBack) {
   ASSERT_STREQ(helloWorld, reread);
   ASSERT_STREQ(helloWorld, buf);
 }
+
+TEST_F(BufferedStreamTest, ReadWithNoWrite) {
+  char helloWorld[] = "Hello world!";
+  leap::BufferedStream bs{ helloWorld, sizeof(helloWorld), sizeof(helloWorld) - 1 };
+
+  char buf[sizeof(helloWorld) * 2] = {};
+  ASSERT_EQ(sizeof(helloWorld) - 1, bs.Read(buf, sizeof(buf)));
+  ASSERT_STREQ(helloWorld, buf);
+}


### PR DESCRIPTION
It's helpful to be able to specify, on creation, the number of bytes from the input buffer which should be treated as valid and ready-to-read.  Modify the buffered stream constructor to support this use pattern and extend tests to verify it works as we expect.