### PR TITLE
Fix inconsistent stream EOF behaviors

### DIFF
--- a/LeapSerial/BufferedStream.h
+++ b/LeapSerial/BufferedStream.h
@@ -4,7 +4,7 @@
 #include "IOutputStream.h"
 
 namespace leap {
-  class BufferedStream :
+  class BufferedStream final :
     public leap::IInputStream,
     public leap::IOutputStream
   {
@@ -29,9 +29,12 @@ namespace leap {
     // A pointer to our WRITE offset in the buffer
     size_t m_writeOffset;
 
+    // True if the last read operation resulted in EOF
+    bool m_eof = false;
+
   public:
     bool Write(const void* pBuf, std::streamsize ncb) override;
-    bool IsEof(void) const override;
+    bool IsEof(void) const override { return m_eof; }
     std::streamsize Read(void* pBuf, std::streamsize ncb) override;
     std::streamsize Skip(std::streamsize ncb) override;
     std::streamsize Length(void) override;

--- a/LeapSerial/FilterStreamBase.h
+++ b/LeapSerial/FilterStreamBase.h
@@ -21,6 +21,9 @@ namespace leap {
   protected:
     const std::unique_ptr<IInputStream> is;
 
+    // EOF flag
+    bool eof = false;
+
     // Fail flag
     bool fail = false;
 
@@ -42,7 +45,7 @@ namespace leap {
 
   public:
     // IInputStream overrides:
-    bool IsEof(void) const override;
+    bool IsEof(void) const override { return eof; }
     std::streamsize Read(void* pBuf, std::streamsize ncb) override;
     std::streamsize Skip(std::streamsize ncb) override;
   };

--- a/LeapSerial/MemoryStream.h
+++ b/LeapSerial/MemoryStream.h
@@ -23,9 +23,12 @@ namespace leap {
     // A pointer to our WRITE offset in the buffer
     size_t m_writeOffset = 0;
 
+    // EOF flag
+    bool m_eof = false;
+
   public:
     bool Write(const void* pBuf, std::streamsize ncb) override;
-    bool IsEof(void) const override;
+    bool IsEof(void) const override { return m_eof; }
     std::streamsize Read(void* pBuf, std::streamsize ncb) override;
     std::streamsize Skip(std::streamsize ncb) override;
     std::streamsize Length(void) override;

--- a/src/leapserial/BufferedStream.cpp
+++ b/src/leapserial/BufferedStream.cpp
@@ -12,7 +12,6 @@ BufferedStream::BufferedStream(void* buffer, size_t ncbBuffer, size_t ncbInitial
   m_writeOffset(ncbInitialValid)
 {}
 
-
 bool BufferedStream::Write(const void* pBuf, std::streamsize ncb) {
   if (ncbBuffer - m_writeOffset < static_cast<size_t>(ncb))
     // Limit hit, no resize possible!
@@ -27,10 +26,6 @@ bool BufferedStream::Write(const void* pBuf, std::streamsize ncb) {
   return true;
 }
 
-bool BufferedStream::IsEof(void) const {
-  return m_readOffset >= ncbBuffer;
-}
-
 std::streamsize BufferedStream::Read(void* pBuf, std::streamsize ncb) {
   const void* pSrcData = static_cast<uint8_t*>(buffer) + m_readOffset;
   ncb = Skip(ncb);
@@ -39,18 +34,19 @@ std::streamsize BufferedStream::Read(void* pBuf, std::streamsize ncb) {
 }
 
 std::streamsize BufferedStream::Skip(std::streamsize ncb) {
-  ncb = std::min(
+  auto skipCount = std::min(
     ncb,
     static_cast<std::streamsize>(m_writeOffset - m_readOffset)
   );
-  m_readOffset += static_cast<size_t>(ncb);
+  m_eof = skipCount != ncb;
+  m_readOffset += static_cast<size_t>(skipCount);
 
-  if (m_readOffset == ncbBuffer) {
+  if (m_readOffset == m_writeOffset) {
     // Reset criteria, no data left in the buffer
     m_readOffset = 0;
     m_writeOffset = 0;
   }
-  return ncb;
+  return skipCount;
 }
 
 std::streamsize BufferedStream::Length(void) {

--- a/src/leapserial/MemoryStream.cpp
+++ b/src/leapserial/MemoryStream.cpp
@@ -42,7 +42,7 @@ std::streamsize MemoryStream::Skip(std::streamsize ncb) {
   m_eof = nSkipped != ncb;
   m_readOffset += static_cast<size_t>(nSkipped);
 
-  if (m_readOffset == buffer.size()) {
+  if (m_readOffset == m_writeOffset) {
     // Reset criteria, no data left in the buffer
     m_readOffset = 0;
     m_writeOffset = 0;

--- a/src/leapserial/MemoryStream.cpp
+++ b/src/leapserial/MemoryStream.cpp
@@ -27,10 +27,6 @@ bool MemoryStream::Write(const void* pBuf, std::streamsize ncb) {
   return true;
 }
 
-bool MemoryStream::IsEof(void) const {
-  return m_readOffset >= buffer.size();
-}
-
 std::streamsize MemoryStream::Read(void* pBuf, std::streamsize ncb) {
   const void* pSrcData = buffer.data() + m_readOffset;
   ncb = Skip(ncb);
@@ -39,18 +35,19 @@ std::streamsize MemoryStream::Read(void* pBuf, std::streamsize ncb) {
 }
 
 std::streamsize MemoryStream::Skip(std::streamsize ncb) {
-  ncb = std::min(
+  std::streamsize nSkipped = std::min(
     ncb,
     static_cast<std::streamsize>(m_writeOffset - m_readOffset)
   );
-  m_readOffset += static_cast<size_t>(ncb);
+  m_eof = nSkipped != ncb;
+  m_readOffset += static_cast<size_t>(nSkipped);
 
   if (m_readOffset == buffer.size()) {
     // Reset criteria, no data left in the buffer
     m_readOffset = 0;
     m_writeOffset = 0;
   }
-  return ncb;
+  return nSkipped;
 }
 
 std::streamsize MemoryStream::Length(void) {

--- a/src/leapserial/test/BufferedStreamTest.cpp
+++ b/src/leapserial/test/BufferedStreamTest.cpp
@@ -30,3 +30,24 @@ TEST_F(BufferedStreamTest, ReadWithNoWrite) {
   ASSERT_EQ(sizeof(helloWorld) - 1, bs.Read(buf, sizeof(buf)));
   ASSERT_STREQ(helloWorld, buf);
 }
+
+TEST_F(BufferedStreamTest, EofCheck) {
+  char buf[200];
+  leap::BufferedStream bs{ buf, sizeof(buf) };
+
+  // EOF not initially set until a read is attempted
+  ASSERT_FALSE(bs.IsEof());
+  ASSERT_EQ(0, bs.Read(buf, 1));
+  ASSERT_TRUE(bs.IsEof());
+
+  // Write, but EOF flag should be sticky
+  ASSERT_TRUE(bs.Write("a", 1));
+  ASSERT_TRUE(bs.IsEof());
+  ASSERT_EQ(1, bs.Read(buf, 1));
+  ASSERT_FALSE(bs.IsEof());
+
+  // Write again and attempt to read more than is available--this should also set EOF
+  bs.Write("abc", 3);
+  ASSERT_EQ(3, bs.Read(buf, sizeof(buf)));
+  ASSERT_TRUE(bs.IsEof());
+}


### PR DESCRIPTION
Some streams are throwing exceptions when the EOF is reached, others set the EOF bit exactly when the last byte is read from the stream, and others still set the EOF bit when an attempt is made to read beyond the end of the file.

Standardize on the behavior defined by the STL:  The EOF bit indicates whether the last read operation read past the end of the file.  This bit gets set even if the last read operation successfully moved some data.