### PR TITLE
Enhance speed of `Skip` function

### DIFF
--- a/src/leapserial/StreamAdapter.cpp
+++ b/src/leapserial/StreamAdapter.cpp
@@ -32,7 +32,7 @@ std::streamsize InputStreamAdapter::Read(void* pBuf, std::streamsize ncb) {
 }
 
 std::streamsize InputStreamAdapter::Skip(std::streamsize ncb) {
-  is.ignore(ncb);
+  is.seekg(ncb, std::ios::cur);
   if (is.fail() && !is.eof())
     return -1;
   return is.gcount();


### PR DESCRIPTION
Skip for the `InputStreamAdapter` type uses a very slow call to `ignore`; this can be made significantly faster if we just use a seek call directly.