### PR TITLE
Add missing source file

### DIFF
--- a/src/LeapSerial/CMakeLists.txt
+++ b/src/LeapSerial/CMakeLists.txt
@@ -31,6 +31,7 @@ set(LeapSerial_SRCS
   FilterStreamBase.h
   FilterStreamBase.cpp
   ForwardingStream.h
+  IArchiveProtobuf.h
   IArchiveProtobuf.cpp
   OArchiveProtobuf.cpp
   IArray.h


### PR DESCRIPTION
Even though it's a header it must be explicitly named, otherwise it won't get packaged during the install step.