### PR TITLE
Bump LeapSerial version number

### DIFF
--- a/version.cmake
+++ b/version.cmake
@@ -1,1 +1,1 @@
-set(LeapSerial_VERSION 0.3.3)
+set(LeapSerial_VERSION 0.4.0)


### PR DESCRIPTION
There have been breaking changes in the LeapSerial interface and includes, need to update the version number accordingly.