### PR TITLE
Fix initialization race in MSVC2013

### DIFF
--- a/src/LeapSerial/descriptors.cpp
+++ b/src/LeapSerial/descriptors.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "descriptors.h"
+#include "Descriptor.h"
 #include <atomic>
 
 using namespace leap;

--- a/src/LeapSerial/descriptors.cpp
+++ b/src/LeapSerial/descriptors.cpp
@@ -13,6 +13,16 @@ descriptor_entry::descriptor_entry(const std::type_info& ti, const descriptor& (
 
 const descriptor_entry* descriptors::s_pHead = nullptr;
 
+#if _MSC_VER <= 1800
+// Used for MSVC2013 because it doesn't have magic statics, so we have to initialize all
+// of our cached descriptors to ensure that we don't wind up with initialization races.
+static bool global_initializer = [] {
+  for (auto& cur : descriptors{})
+    cur.pfnDesc();
+  return true;
+}();
+#endif
+
 const descriptor_entry* descriptors::Link(descriptor_entry& entry) {
   auto retVal = s_pHead;
   s_pHead = &entry;


### PR DESCRIPTION
MSVC2013 before the CTP doesn't have magic statics, so we need to make sure all of our descriptors are initialized on that platform in advance.