### PR TITLE
Restore PathologicalTest

### DIFF
--- a/src/LeapSerial/test/CMakeLists.txt
+++ b/src/LeapSerial/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LeapSerialTest_SRCS
   MapTest.cpp
   MemoryStreamTest.cpp
   OptionalTest.cpp
+  PathologicalTest.cpp
   PrettyPrintTest.cpp
   SerialCallbackTest.cpp
   SerialFormatTest.cpp

--- a/src/LeapSerial/test/PathologicalTest.cpp
+++ b/src/LeapSerial/test/PathologicalTest.cpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
-#include "LeapSerial.h"
+#include <LeapSerial/LeapSerial.h>
 #include <gtest/gtest.h>
 #include <array>
 #include <sstream>


### PR DESCRIPTION
Looks like this test got forgotten about when the project was refactored, put it back in CMakeLists.txt and make it compile.