### PR TITLE
Minimal repro case for a bool issue

### DIFF
--- a/src/LeapSerial/ArchiveLeapSerial.cpp
+++ b/src/LeapSerial/ArchiveLeapSerial.cpp
@@ -247,9 +247,9 @@ void IArchiveLeapSerial::Transfer(internal::AllocationBase& alloc) {
 }
 
 bool IArchiveLeapSerial::ReadBool() {
-  bool b;
+  uint8_t b;
   ReadByteArray(&b, 1);
-  return b;
+  return !!b;
 }
 
 uint64_t IArchiveLeapSerial::ReadInteger(uint8_t) {
@@ -433,7 +433,8 @@ void OArchiveLeapSerial::WriteString(const void* pBuf, uint64_t charCount, uint8
 }
 
 void OArchiveLeapSerial::WriteBool(bool value) {
-  WriteByteArray(&value, 1);
+  uint8_t v = value ? 1 : 0;
+  WriteByteArray(&v, 1);
 }
 
 void OArchiveLeapSerial::WriteInteger(int64_t value, uint8_t) {

--- a/src/LeapSerial/ArchiveLeapSerial.cpp
+++ b/src/LeapSerial/ArchiveLeapSerial.cpp
@@ -433,7 +433,7 @@ void OArchiveLeapSerial::WriteString(const void* pBuf, uint64_t charCount, uint8
 }
 
 void OArchiveLeapSerial::WriteBool(bool value) {
-  WriteInteger(value, sizeof(bool));
+  WriteByteArray(&value, 1);
 }
 
 void OArchiveLeapSerial::WriteInteger(int64_t value, uint8_t) {

--- a/src/LeapSerial/test/PathologicalTest.cpp
+++ b/src/LeapSerial/test/PathologicalTest.cpp
@@ -36,3 +36,23 @@ TEST(PathologicalTest, ComplexMapOfStringToVectorTest) {
   ASSERT_EQ(8, c[1]);
   ASSERT_EQ(9, c[2]);
 }
+
+struct HasBoolAndVector {
+  bool bVal;
+  std::vector<int> vect;
+  static leap::descriptor GetDescriptor() {
+    return{
+      &HasBoolAndVector::bVal,
+      &HasBoolAndVector::vect
+    };
+  }
+};
+
+TEST(PathologicalTest, PathologicalBool) {
+  std::stringstream ss;
+  HasBoolAndVector sd;
+  leap::Serialize(ss, sd);
+
+  std::shared_ptr<HasBoolAndVector> psd;
+  ASSERT_NO_THROW(psd = leap::Deserialize<HasBoolAndVector>(ss));
+}


### PR DESCRIPTION
Looks like LeapSerial's base format isn't serializing and deserializing `bool` the same way.  Add a test to ensure we don't goof this up again, and then fix the issue.