### PR TITLE
Make compressions stream test a bit more pathological

### DIFF
--- a/src/LeapSerial/FilterStreamBase.h
+++ b/src/LeapSerial/FilterStreamBase.h
@@ -61,7 +61,7 @@ namespace leap {
 
     ~OutputFilterStreamBase(void);
 
-  private:
+  protected:
     // Base output stream, where our data goes
     const std::unique_ptr<IOutputStream> os;
 
@@ -71,7 +71,6 @@ namespace leap {
     // Fail bit, used to indicate something went wrong with compression
     bool fail = false;
 
-  protected:
     /// <summary>
     /// In-memory transform operation
     /// </summary>


### PR DESCRIPTION
There are some defects that are only obvious when the compression stream is very large.  Make the unit tests verify the correct behavior of the compression stream when the input is very large, and fix any bugs that are uncovered.