### PR TITLE
Refactor compression stream

### DIFF
--- a/src/LeapSerial/CompressionStream.cpp
+++ b/src/LeapSerial/CompressionStream.cpp
@@ -1,79 +1,101 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "CompressionStream.h"
+#include "LeapSerial.h"
 #include <algorithm>
 #include <memory.h>
 #include <zlib/zlib.h>
 
-using namespace leap;
+namespace leap {
 
-ZStreamBase::ZStreamBase(void) :
-  strm{ new z_stream }
-{
-  strm->zalloc = nullptr;
-  strm->zfree = nullptr;
-  strm->opaque = nullptr;
-}
+struct Zlib {
+  Zlib(void) {
+    strm.zalloc = nullptr;
+    strm.zfree = nullptr;
+    strm.opaque = nullptr;
+    strm.avail_in = 0;
+    strm.next_in = nullptr;
+  }
 
-ZStreamBase::ZStreamBase(ZStreamBase&& rhs) :
-  strm(std::move(rhs.strm))
-{}
+  // zlib state
+  z_stream_s strm;
+};
 
-ZStreamBase::~ZStreamBase(void) {
-  if(strm)
-    deflateEnd(strm.get());
-}
+// Zlib decompressor
+template<> Decompressor<Zlib>::Decompressor(void) : impl{leap::make_unique<Zlib>()} { inflateInit(&impl->strm); }
+template<> Decompressor<Zlib>::~Decompressor(void) { inflateEnd(&impl->strm); }
 
-DecompressionStream::DecompressionStream(std::unique_ptr<IInputStream>&& is) :
-  InputFilterStreamBase(std::move(is))
-{
-  inflateInit(strm.get());
-  strm->avail_in = 0;
-  strm->next_in = nullptr;
-}
-
-bool DecompressionStream::Transform(const void* input, size_t& ncbIn, void* output, size_t& ncbOut) {
-  // Decompress into our buffer space
-  strm->next_out = reinterpret_cast<uint8_t*>(output);
-  strm->avail_out = static_cast<uint32_t>(ncbOut);
-  strm->next_in = reinterpret_cast<const uint8_t*>(input);
-  strm->avail_in = static_cast<uint32_t>(ncbIn);
-  if (inflate(strm.get(), Z_NO_FLUSH) == Z_STREAM_ERROR)
-    return false;
-
-  // Store the amount we actually read/wrote
-  ncbIn -= strm->avail_in;
-  ncbOut -= strm->avail_out;
-  return true;
-}
-
-CompressionStream::CompressionStream(std::unique_ptr<IOutputStream>&& os, int level) :
-  OutputFilterStreamBase(std::move(os))
-{
+// Zlib compressor
+template<> Compressor<Zlib>::Compressor(int level) : impl{leap::make_unique<Zlib>()} {
   if (level < -1 || 9 < level)
     throw std::invalid_argument("Compression stream level must be in the range [0, 9]");
 
-  deflateInit(strm.get(), level);
+  deflateInit(&impl->strm, level);
+}
+template<> Compressor<Zlib>::~Compressor(void) { deflateEnd(&impl->strm); }
+
+template<typename T>
+DecompressionStream<T>::DecompressionStream(std::unique_ptr<IInputStream>&& is) :
+  InputFilterStreamBase(std::move(is))
+{}
+
+template<typename T>
+bool DecompressionStream<T>::Transform(const void* input, size_t& ncbIn, void* output, size_t& ncbOut) {
+  return false;
 }
 
-CompressionStream::~CompressionStream(void) {
+template<typename T>
+CompressionStream<T>::CompressionStream(std::unique_ptr<IOutputStream>&& os, int level) :
+  OutputFilterStreamBase(std::move(os)),
+  Compressor<T>(level)
+{}
+
+template<typename T>
+CompressionStream<T>::~CompressionStream(void)
+{}
+
+template<typename T>
+bool CompressionStream<T>::Transform(const void* input, size_t& ncbIn, void* output, size_t& ncbOut, bool flush) {
+  return false;
+}
+
+// Zlib specialization
+
+template<>
+bool DecompressionStream<Zlib>::Transform(const void* input, size_t& ncbIn, void* output, size_t& ncbOut) {
+  // Decompress into our buffer space
+  impl->strm.next_out = reinterpret_cast<uint8_t*>(output);
+  impl->strm.avail_out = static_cast<uint32_t>(ncbOut);
+  impl->strm.next_in = reinterpret_cast<const uint8_t*>(input);
+  impl->strm.avail_in = static_cast<uint32_t>(ncbIn);
+  if (inflate(&impl->strm, Z_NO_FLUSH) == Z_STREAM_ERROR)
+    return false;
+
+  // Store the amount we actually read/wrote
+  ncbIn -= impl->strm.avail_in;
+  ncbOut -= impl->strm.avail_out;
+  return true;
+}
+
+template<>
+CompressionStream<Zlib>::~CompressionStream(void) {
   uint8_t buf[256];
 
   // Completed!  Finish writing anything that remains to be written, and keep going
   // as long as zlib fills up the proffered output buffer.
-  for(;;) {
-    strm->avail_in = 0;
-    strm->next_in = nullptr;
-    strm->next_out = buf;
-    strm->avail_out = sizeof(buf);
+  for (;;) {
+    impl->strm.avail_in = 0;
+    impl->strm.next_in = nullptr;
+    impl->strm.next_out = buf;
+    impl->strm.avail_out = sizeof(buf);
 
-    int ret = deflate(strm.get(), Z_FINISH);
+    int ret = deflate(&impl->strm, Z_FINISH);
     switch (ret) {
     case Z_STREAM_END:  // Return case when we are at the end
     case Z_OK:          // Return case when more data exists to be written
 
       // Handoff to lower level stream to complete the write
-      os->Write(buf, sizeof(buf) - strm->avail_out);
+      os->Write(buf, sizeof(buf) - impl->strm.avail_out);
 
       if (ret == Z_STREAM_END)
         // Clean return
@@ -86,16 +108,23 @@ CompressionStream::~CompressionStream(void) {
   }
 }
 
-bool CompressionStream::Transform(const void* input, size_t& ncbIn, void* output, size_t& ncbOut, bool flush) {
-  strm->avail_in = static_cast<uint32_t>(ncbIn);
-  strm->next_in = reinterpret_cast<const uint8_t*>(input);
+template<>
+bool CompressionStream<Zlib>::Transform(const void* input, size_t& ncbIn, void* output, size_t& ncbOut, bool flush) {
+  impl->strm.avail_in = static_cast<uint32_t>(ncbIn);
+  impl->strm.next_in = reinterpret_cast<const uint8_t*>(input);
 
   // Compress one, update results
-  strm->next_out = reinterpret_cast<uint8_t*>(output);
-  strm->avail_out = static_cast<uint32_t>(ncbOut);
-  int rs = deflate(strm.get(), flush ? Z_FULL_FLUSH : Z_NO_FLUSH);
+  impl->strm.next_out = reinterpret_cast<uint8_t*>(output);
+  impl->strm.avail_out = static_cast<uint32_t>(ncbOut);
+  int rs = deflate(&impl->strm, flush ? Z_FULL_FLUSH : Z_NO_FLUSH);
 
-  ncbIn -= strm->avail_in;
-  ncbOut -= strm->avail_out;
+  ncbIn -= impl->strm.avail_in;
+  ncbOut -= impl->strm.avail_out;
   return rs == Z_OK;
 }
+
+}
+
+// Explicit template specialization for the supported types:
+template class leap::DecompressionStream<leap::Zlib>;
+template class leap::CompressionStream<leap::Zlib>;

--- a/src/LeapSerial/CompressionStream.h
+++ b/src/LeapSerial/CompressionStream.h
@@ -5,26 +5,44 @@
 #include <memory>
 #include <vector>
 
-struct z_stream_s;
-
 namespace leap {
-  class ZStreamBase {
-  public:
-    ZStreamBase(void);
-    ZStreamBase(ZStreamBase&& rhs);
-    ~ZStreamBase(void);
 
+  /// <summary>
+  /// Supported compression/decompression implementations:
+  /// </summary>
+  struct Zlib;
+
+  /// <summary>
+  /// Decompression interface
+  /// </summary>
+  template<typename T>
+  class Decompressor {
+  public:
+    Decompressor(void);
+    ~Decompressor(void);
   protected:
-    // zlib state
-    std::unique_ptr<z_stream_s> strm;
+    std::unique_ptr<T> impl;
+  };
+
+  /// <summary>
+  /// Compression interface
+  /// </summary>
+  template<typename T>
+  class Compressor {
+  public:
+    Compressor(int level = 9);
+    ~Compressor(void);
+  protected:
+    std::unique_ptr<T> impl;
   };
 
   /// <summary>
   /// Input decompression stream
   /// <summary>
+  template<typename T = Zlib>
   class DecompressionStream :
     public InputFilterStreamBase,
-    public ZStreamBase
+    public Decompressor<T>
   {
   public:
     /// <summary>
@@ -34,15 +52,16 @@ namespace leap {
 
   protected:
     // InputFilterStreamBase overrides:
-    bool Transform(const void* input, size_t& ncbIn, void* output, size_t& ncbOut) override;
+    bool Transform(const void* input, size_t& ncbIn, void* output, size_t& ncbOut);
   };
 
   /// <summary>
-  /// Output decompression stream
+  /// Output compression stream
   /// <summary>
+  template<typename T = Zlib>
   class CompressionStream :
     public OutputFilterStreamBase,
-    public ZStreamBase
+    public Compressor<T>
   {
   public:
     /// <summary>

--- a/src/LeapSerial/FilterStreamBase.cpp
+++ b/src/LeapSerial/FilterStreamBase.cpp
@@ -47,6 +47,7 @@ std::streamsize InputFilterStreamBase::Read(void* pBuf, std::streamsize ncb) {
 
       // Handoff to transform behavior:
       size_t ncbIn = static_cast<size_t>(nRead);
+      buffer.resize(1024);
       ncbAvail = buffer.size();
       if(!Transform(inputChunk.data(), ncbIn, buffer.data(), ncbAvail))
         return -1;

--- a/src/LeapSerial/test/CompressionStreamTest.cpp
+++ b/src/LeapSerial/test/CompressionStreamTest.cpp
@@ -51,7 +51,7 @@ TEST_F(CompressionStreamTest, KnownValueRoundTrip) {
   std::stringstream ss;
 
   {
-    leap::CompressionStream cs(
+    leap::CompressionStream<leap::Zlib> cs(
       leap::make_unique<leap::OutputStreamAdapter>(ss)
     );
     cs.Write(vec.data(), vec.size());
@@ -59,7 +59,7 @@ TEST_F(CompressionStreamTest, KnownValueRoundTrip) {
 
   ss.seekg(0);
 
-  leap::DecompressionStream ds{
+  leap::DecompressionStream<leap::Zlib> ds{
     leap::make_unique<leap::InputStreamAdapter>(ss)
   };
 
@@ -73,7 +73,7 @@ TEST_F(CompressionStreamTest, CompressionPropCheck) {
 
   std::stringstream ss;
   {
-    leap::CompressionStream cs{
+    leap::CompressionStream<leap::Zlib> cs{
       leap::make_unique<leap::OutputStreamAdapter>(ss),
       9
     };
@@ -93,7 +93,7 @@ TEST_P(CompressionStreamTestF, RoundTrip) {
 
   std::stringstream ss;
   {
-    leap::CompressionStream cs{
+    leap::CompressionStream<leap::Zlib> cs{
       leap::make_unique<leap::OutputStreamAdapter>(ss)
     };
     leap::Serialize(cs, val);
@@ -101,7 +101,7 @@ TEST_P(CompressionStreamTestF, RoundTrip) {
 
   SimpleStruct reacq;
   {
-    leap::DecompressionStream ds{
+    leap::DecompressionStream<leap::Zlib> ds{
       leap::make_unique<leap::InputStreamAdapter>(ss)
     };
     leap::Deserialize(ds, reacq);
@@ -116,7 +116,7 @@ TEST_P(CompressionStreamTestF, TruncatedStreamTest) {
   std::string str;
   {
     std::stringstream ss;
-    leap::CompressionStream cs{
+    leap::CompressionStream<leap::Zlib> cs{
       leap::make_unique<leap::OutputStreamAdapter>(ss)
     };
     leap::Serialize(cs, val);
@@ -130,7 +130,7 @@ TEST_P(CompressionStreamTestF, TruncatedStreamTest) {
   SimpleStruct reacq;
   {
     std::stringstream ss(std::move(str));
-    leap::DecompressionStream ds{
+    leap::DecompressionStream<leap::Zlib> ds{
       leap::make_unique<leap::InputStreamAdapter>(ss)
     };
     ASSERT_ANY_THROW(leap::Deserialize(ds, reacq));
@@ -146,8 +146,8 @@ INSTANTIATE_TEST_CASE_P(
 TEST_F(CompressionStreamTest, EofCheck) {
   char buf[200];
   leap::BufferedStream bs(buf, sizeof(buf));
-  leap::CompressionStream cs{ leap::make_unique<leap::ForwardingOutputStream>(bs) };
-  leap::DecompressionStream dcs{ leap::make_unique<leap::ForwardingInputStream>(bs) };
+  leap::CompressionStream<leap::Zlib> cs{ leap::make_unique<leap::ForwardingOutputStream>(bs) };
+  leap::DecompressionStream<leap::Zlib> dcs{ leap::make_unique<leap::ForwardingInputStream>(bs) };
 
   // EOF not initially set until a read is attempted
   ASSERT_FALSE(dcs.IsEof());

--- a/src/LeapSerial/test/CompressionStreamTest.cpp
+++ b/src/LeapSerial/test/CompressionStreamTest.cpp
@@ -116,10 +116,15 @@ TEST_P(CompressionStreamTestF, TruncatedStreamTest) {
   std::string str;
   {
     std::stringstream ss;
-    leap::CompressionStream<leap::Zlib> cs{
-      leap::make_unique<leap::OutputStreamAdapter>(ss)
-    };
-    leap::Serialize(cs, val);
+    {
+      leap::CompressionStream<leap::Zlib> cs{
+        leap::make_unique<leap::OutputStreamAdapter>(ss)
+      };
+      leap::Serialize(cs, val);
+    }
+    // To capture the entire compressed stream, we need to "finish" it first.
+    // This is accomplished by destructing the compression stream. Flushing
+    // isn't sufficient, as it doesn't include the trailer.
     str = ss.str();
   }
 


### PR DESCRIPTION
Compression streams were fix to use the Zlib compression. This PR adds the ability to more easily support other compression schemes. It also fixes a couple of bugs.

IMPORTANT: This does include a breaking interface changes as well. The `leap::CompressionStream` and `leap::DecompressionStream` classes are now templated, specifying the compression type.