### PR TITLE
Fix protobuf compatibility and support

### DIFF
--- a/cmake-modules/FindProtobuf.cmake
+++ b/cmake-modules/FindProtobuf.cmake
@@ -48,6 +48,10 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Protobuf DEFAULT_MSG
                                   Protobuf_LIBRARY Protobuf_INCLUDE_DIR)
 
+if(NOT Protobuf)
+  return()
+endif()
+
 generate_import_target(Protobuf STATIC TARGET protobuf::protobuf)
 include(CMakeFindDependencyMacro)
 find_dependency(ZLIB)

--- a/cmake-modules/FindProtobuf.cmake
+++ b/cmake-modules/FindProtobuf.cmake
@@ -21,7 +21,9 @@ find_path(Protobuf_HOST_DIR
                 protobuf
   NO_CMAKE_PATH)
 
-set(Protobuf_INCLUDE_DIR ${Protobuf_ROOT_DIR}/include CACHE STRING "")
+find_path(Protobuf_INCLUDE_DIR
+  NAMES google/protobuf/descriptor.h
+  HINTS ${Protobuf_ROOT_DIR}/include CACHE STRING "")
 
 if(DEFINED Protobuf_LIBRARY AND NOT EXISTS ${Protobuf_LIBRARY})
   unset(Protobuf_LIBRARY CACHE)

--- a/cmake-modules/FindProtobuf.cmake
+++ b/cmake-modules/FindProtobuf.cmake
@@ -48,7 +48,7 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Protobuf DEFAULT_MSG
                                   Protobuf_LIBRARY Protobuf_INCLUDE_DIR)
 
-if(NOT Protobuf)
+if(NOT Protobuf_FOUND)
   return()
 endif()
 

--- a/cmake-modules/FindProtobuf.cmake
+++ b/cmake-modules/FindProtobuf.cmake
@@ -30,7 +30,7 @@ if(DEFINED Protobuf_LIBRARY AND NOT EXISTS ${Protobuf_LIBRARY})
 endif()
 
 find_library(Protobuf_LIBRARY
-  NAMES protobuf libprotobuf #This is dumb, but nessecary because on mac, the prefix is "lib", but on windows its ""
+  NAMES protobuf libprotobuf #This is dumb, but necessary because on mac, the prefix is "lib", but on windows its ""
   HINTS "${Protobuf_ROOT_DIR}/lib"
         "${Protobuf_ROOT_DIR}/lib/Release"
 )

--- a/cmake-modules/FindProtobuf.cmake
+++ b/cmake-modules/FindProtobuf.cmake
@@ -8,13 +8,17 @@ if(APPLE)
 find_path(Protobuf_ROOT_DIR
   NAMES include/google/protobuf/descriptor.h
   PATH_SUFFIXES protobuf-${Protobuf_FIND_VERSION}${_suffix}
-                protobuf${_suffix})
+                protobuf${_suffix}
+                protobuf-${Protobuf_FIND_VERSION}
+                protobuf)
 
 find_path(Protobuf_HOST_DIR
   NAMES include/google/protobuf/descriptor.h
   HINTS ${Protobuf_ROOT_DIR}
   PATH_SUFFIXES protobuf-${Protobuf_FIND_VERSION}${_suffix}
                 protobuf${_suffix}
+                protobuf-${Protobuf_FIND_VERSION}
+                protobuf
   NO_CMAKE_PATH)
 
 set(Protobuf_INCLUDE_DIR ${Protobuf_ROOT_DIR}/include CACHE STRING "")
@@ -24,18 +28,18 @@ if(DEFINED Protobuf_LIBRARY AND NOT EXISTS ${Protobuf_LIBRARY})
 endif()
 
 find_library(Protobuf_LIBRARY
-  NAMES protobuf libprotobuf #This is dumb, but necessary because on mac, the prefix is "lib", but on windows its ""
+  NAMES protobuf libprotobuf #This is dumb, but nessecary because on mac, the prefix is "lib", but on windows its ""
   HINTS "${Protobuf_ROOT_DIR}/lib"
         "${Protobuf_ROOT_DIR}/lib/Release"
 )
 
 if(WIN32)
-  set(Protobuf_LIBRARY_RELEASE ${Protobuf_LIBRARY})
+  set(Protobuf_LIBRARY_RELEASE ${Protobuf_LIBRARY} CACHE FILEPATH "")
   find_library(Protobuf_LIBRARY_DEBUG
-    NAMES protobuf libprotobuf
-    HINTS ${Protobuf_ROOT_DIR}/lib/Debug
+    NAMES libprotobufd
+    HINTS ${Protobuf_ROOT_DIR}/lib/Debug ${Protobuf_ROOT_DIR}/lib
   )
-  mark_as_advanced(Protobuf_LIBRARY_DEBUG)
+  mark_as_advanced(Protobuf_LIBRARY_DEBUG Protobuf_LIBRARY_RELEASE)
 endif()
 
 find_program(Protobuf_protoc protoc HINTS ${Protobuf_HOST_DIR} PATH_SUFFIXES bin${CROSS_COMPILE_EXE_TYPE} bin NO_CMAKE_PATH)
@@ -44,15 +48,10 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Protobuf DEFAULT_MSG
                                   Protobuf_LIBRARY Protobuf_INCLUDE_DIR)
 
-if(NOT Protobuf_HOST_DIR OR NOT Protobuf_ROOT_DIR OR NOT Protobuf_protoc OR NOT Protobuf)
-  return()
-endif()
-
-generate_import_target(Protobuf STATIC)
-
+generate_import_target(Protobuf STATIC TARGET protobuf::protobuf)
 include(CMakeFindDependencyMacro)
 find_dependency(ZLIB)
-set_property(TARGET Protobuf::Protobuf APPEND PROPERTY INTERFACE_LINK_LIBRARIES ZLIB::ZLIB)
+set_property(TARGET protobuf::protobuf APPEND PROPERTY INTERFACE_LINK_LIBRARIES ZLIB::ZLIB)
 
-add_executable(Protobuf::protoc IMPORTED)
-set_property(TARGET Protobuf::protoc PROPERTY IMPORTED_LOCATION ${Protobuf_protoc})
+add_executable(protobuf::protoc IMPORTED)
+set_property(TARGET protobuf::protoc PROPERTY IMPORTED_LOCATION ${Protobuf_protoc})

--- a/src/LeapSerial/SchemaWriterProtobuf.h
+++ b/src/LeapSerial/SchemaWriterProtobuf.h
@@ -53,8 +53,9 @@ namespace leap {
   };
 
   class SchemaWriterProtobuf2:
-    SchemaWriterProtobuf
+    public SchemaWriterProtobuf
   {
+  public:
     SchemaWriterProtobuf2(const descriptor& desc) :
       SchemaWriterProtobuf(desc, protobuf::Version::Proto2)
     {}

--- a/src/LeapSerial/test/ArchiveProtobufTest.cpp
+++ b/src/LeapSerial/test/ArchiveProtobufTest.cpp
@@ -9,8 +9,12 @@
 
 // This is required on Windows due to the way protobuf uses std::copy
 #define _SCL_SECURE_NO_WARNINGS
+#pragma warning(push)
+#pragma warning(disable: 4244)
+#pragma warning(disable: 4267)
 #include "TestProtobuf.pb.h"
 #undef _SCL_SECURE_NO_WARNINGS
+#pragma warning(pop)
 
 static std::string ToProtobuf(const Person& in) {
   // Write the protobuf version first:
@@ -53,7 +57,7 @@ TEST(ArchiveProtobufTest, LeapSerialToProtobuf) {
   const Person defaultPerson = MakeDefaultPerson();
 
   std::stringstream ss;
-  leap::Serialize<leap::OArchiveProtobuf>(leap::OutputStreamAdapter(ss), defaultPerson);
+  leap::Serialize<leap::OArchiveProtobuf>(ss, defaultPerson);
   std::string val = ss.str();
 
   leap::test::Person person;

--- a/src/LeapSerial/test/CMakeLists.txt
+++ b/src/LeapSerial/test/CMakeLists.txt
@@ -24,24 +24,27 @@ add_pch(LeapSerialTest_SRCS "stdafx.h" "stdafx.cpp")
 find_package(FlatBuffers QUIET)
 if(FlatBuffers)
   add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/TestObject_generated.h
-    COMMAND FlatBuffers::flatc -c -I ${CMAKE_CURRENT_SOURCE_DIR} -o ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/TestObject.fbs
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/TestObject_generated.h
+    COMMAND FlatBuffers::flatc -c -I ${CMAKE_CURRENT_SOURCE_DIR} -o ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/TestObject.fbs
     MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/TestObject.fbs
     COMMENT "Generating TestObject_generated.h"
     VERBATIM
   )
-else()
-  file(WRITE TestObject_generated.h)
+
+  add_conditional_sources(LeapSerialTest_SRCS "TRUE"
+    GROUP_NAME "Flatbuffers"
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/TestObject_generated.h
+  )
+  set_property(SOURCE ${CMAKE_CURRENT_BINARY_DIR}/TestObject_generated.h
+    PROPERTY GROUP_NAME "Flatbuffers"
+  )
 endif()
 
 add_conditional_sources(
   LeapSerialTest_SRCS
   "FlatBuffers"
   GROUP_NAME "FlatBuffers"
-  FILES
-  ArchiveFlatbufferTest.cpp
-  TestObject.fbs
-  TestObject_generated.h
+  FILES ArchiveFlatbufferTest.cpp TestObject.fbs
 )
 
 option(LS_ENABLE_PROTOBUF_TESTS "Enable protobuf tests" ON)
@@ -64,9 +67,9 @@ if(Protobuf_FOUND)
     VERBATIM
   )
 
-  list(APPEND LeapSerialTest_SRCS
-    ${CMAKE_CURRENT_BINARY_DIR}/TestProtobuf.pb.h
-    ${CMAKE_CURRENT_BINARY_DIR}/TestProtobuf.pb.cc
+  add_conditional_sources(LeapSerialTest_SRCS "TRUE"
+    GROUP_NAME "Protobuf"
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/TestProtobuf.pb.h ${CMAKE_CURRENT_BINARY_DIR}/TestProtobuf.pb.cc
   )
 endif()
 
@@ -74,10 +77,7 @@ add_conditional_sources(
   LeapSerialTest_SRCS
   "Protobuf_FOUND"
   GROUP_NAME "Protobuf"
-  FILES
-  ArchiveProtobufTest.cpp
-  SchemaTest.cpp
-  TestProtobuf.proto
+  FILES ArchiveProtobufTest.cpp SchemaTest.cpp TestProtobuf.proto
 )
 
 find_package(Threads)

--- a/src/LeapSerial/test/CMakeLists.txt
+++ b/src/LeapSerial/test/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 
 if(Protobuf_FOUND)
   add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.pb.cc ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.pb.h
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/TestProtobuf.pb.cc ${CMAKE_CURRENT_BINARY_DIR}/TestProtobuf.pb.h
     COMMAND protobuf::protoc
     ARGS -I ${CMAKE_CURRENT_SOURCE_DIR} --cpp_out=${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.proto
     MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.proto
@@ -70,13 +70,13 @@ endif()
 
 add_conditional_sources(
   LeapSerialTest_SRCS
-  Protobuf_FOUND
+  "Protobuf_FOUND"
   GROUP_NAME "Protobuf"
   FILES
   ArchiveProtobufTest.cpp
   SchemaTest.cpp
   TestProtobuf.proto
-  TestProtobuf.pb.h
+  ${CMAKE_CURRENT_BINARY_DIR}/TestProtobuf.pb.h
   ${CMAKE_CURRENT_BINARY_DIR}/TestProtobuf.pb.cc
 )
 

--- a/src/LeapSerial/test/CMakeLists.txt
+++ b/src/LeapSerial/test/CMakeLists.txt
@@ -63,9 +63,11 @@ if(Protobuf_FOUND)
     COMMENT "Generating TestProtobuf.pb.cc and TestProtobuf.pb.h"
     VERBATIM
   )
-else()
-  file(WRITE TestProtobuf.pb.h)
-  file(WRITE TestProtobuf.pb.cc)
+
+  list(APPEND LeapSerialTest_SRCS
+    ${CMAKE_CURRENT_BINARY_DIR}/TestProtobuf.pb.h
+    ${CMAKE_CURRENT_BINARY_DIR}/TestProtobuf.pb.cc
+  )
 endif()
 
 add_conditional_sources(
@@ -76,8 +78,6 @@ add_conditional_sources(
   ArchiveProtobufTest.cpp
   SchemaTest.cpp
   TestProtobuf.proto
-  ${CMAKE_CURRENT_BINARY_DIR}/TestProtobuf.pb.h
-  ${CMAKE_CURRENT_BINARY_DIR}/TestProtobuf.pb.cc
 )
 
 find_package(Threads)

--- a/src/LeapSerial/test/CMakeLists.txt
+++ b/src/LeapSerial/test/CMakeLists.txt
@@ -54,10 +54,11 @@ if(LS_ENABLE_PROTOBUF_TESTS OR LS_PROTOBUF_REQUIRED)
   endif()
 endif()
 
-if(Protobuf)
+if(Protobuf_FOUND)
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.pb.cc ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.pb.h
-    COMMAND Protobuf::protoc -I ${CMAKE_CURRENT_SOURCE_DIR} --cpp_out=${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.proto
+    COMMAND protobuf::protoc
+    ARGS -I ${CMAKE_CURRENT_SOURCE_DIR} --cpp_out=${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.proto
     MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/TestProtobuf.proto
     COMMENT "Generating TestProtobuf.pb.cc and TestProtobuf.pb.h"
     VERBATIM
@@ -69,14 +70,14 @@ endif()
 
 add_conditional_sources(
   LeapSerialTest_SRCS
-  "Protobuf"
+  Protobuf_FOUND
   GROUP_NAME "Protobuf"
   FILES
   ArchiveProtobufTest.cpp
   SchemaTest.cpp
   TestProtobuf.proto
   TestProtobuf.pb.h
-  TestProtobuf.pb.cc
+  ${CMAKE_CURRENT_BINARY_DIR}/TestProtobuf.pb.cc
 )
 
 find_package(Threads)
@@ -84,10 +85,11 @@ add_executable(LeapSerialTest ${LeapSerialTest_SRCS} ../../gtest-all-guard.cpp)
 target_link_libraries(LeapSerialTest LeapSerial ${CMAKE_THREAD_LIBS_INIT})
 add_test(NAME LeapSerialTest COMMAND $<TARGET_FILE:LeapSerialTest>)
 
-if(FlatBuffers)
+if(FlatBuffers_FOUND)
   target_link_libraries(LeapSerialTest FlatBuffers::FlatBuffers)
 endif()
 
-if(Protobuf)
-  target_link_libraries(LeapSerialTest Protobuf::Protobuf)
+if(Protobuf_FOUND)
+  target_link_libraries(LeapSerialTest protobuf::protobuf)
+  target_include_directories(LeapSerialTest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 endif()

--- a/src/LeapSerial/test/SchemaTest.cpp
+++ b/src/LeapSerial/test/SchemaTest.cpp
@@ -2,13 +2,18 @@
 #include "stdafx.h"
 #include "TestProtobufLS.hpp"
 #include <gtest/gtest.h>
-#include <google/protobuf/compiler/importer.h>
-#include <google/protobuf/io/zero_copy_stream.h>
-#include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <LeapSerial/LeapSerial.h>
 #include <array>
 #include <iomanip>
 #include <sstream>
+
+#pragma warning(push)
+#pragma warning(disable: 4244)
+#pragma warning(disable: 4267)
+#include <google/protobuf/compiler/importer.h>
+#include <google/protobuf/io/zero_copy_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#pragma warning(pop)
 
 namespace io = google::protobuf::io;
 namespace cl = google::protobuf::compiler;


### PR DESCRIPTION
The protobuf build for LeapSerial isn't working any more.  Fix it so we can run the tests.  Also suppress warnings where possible--we can't fix the generated code and the warnings make it harder to see real issues.

While we're at it, also fix SchemaWriterProtobuf2's access protections, and simplify the protobuf tests where possible.