### PR TITLE
Explicitly specify syntax = "proto2"

### DIFF
--- a/src/LeapSerial/SchemaWriterProtobuf.cpp
+++ b/src/LeapSerial/SchemaWriterProtobuf.cpp
@@ -131,6 +131,7 @@ void SchemaWriterProtobuf::Write(IOutputStream& os) {
 }
 
 void SchemaWriterProtobuf::Write(std::ostream& os) {
+  os << "syntax = \"proto2\";" << std::endl;
   awaiting.push_back(&Desc);
   encountered.clear();
   synthetic.clear();

--- a/src/LeapSerial/test/TestProtobuf.proto
+++ b/src/LeapSerial/test/TestProtobuf.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package leap.test;
 
 message Pet {


### PR DESCRIPTION
This warning probably started once we updated to protobuf-3.0.0.

Since we're defaulting to `syntax = "proto2"`, and LeapSerial was developed on such, explicitly specify it. This removes the runtime warning:
```
 Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
```