### PR TITLE
Add BZip2 as a supported compression type

### DIFF
--- a/src/LeapSerial/CMakeLists.txt
+++ b/src/LeapSerial/CMakeLists.txt
@@ -61,7 +61,7 @@ set(LeapSerial_SRCS
 
 add_pch(LeapSerial_SRCS "stdafx.h" "stdafx.cpp")
 add_library(LeapSerial ${LeapSerial_SRCS})
-target_link_libraries(LeapSerial aes zlib)
+target_link_libraries(LeapSerial aes zlib bz2)
 target_include_directories(
   LeapSerial
   INTERFACE

--- a/src/LeapSerial/CompressionStream.cpp
+++ b/src/LeapSerial/CompressionStream.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <memory.h>
 #include <zlib/zlib.h>
+#include <bzip2/bzlib.h>
 
 namespace leap {
 
@@ -33,6 +34,33 @@ template<> Compressor<Zlib>::Compressor(int level) : impl{leap::make_unique<Zlib
   deflateInit(&impl->strm, level);
 }
 template<> Compressor<Zlib>::~Compressor(void) { deflateEnd(&impl->strm); }
+
+struct BZip2 {
+  BZip2(void) {
+    strm.bzalloc = nullptr;
+    strm.bzfree = nullptr;
+    strm.opaque = nullptr;
+    strm.avail_in = 0;
+    strm.next_in = nullptr;
+  }
+
+  // zlib state
+  bz_stream strm;
+};
+
+template<> Decompressor<BZip2>::Decompressor(void) : impl{leap::make_unique<BZip2>()} { BZ2_bzDecompressInit(&impl->strm, 0, 0); }
+template<> Decompressor<BZip2>::~Decompressor(void) { BZ2_bzDecompressEnd(&impl->strm); }
+
+template<> Compressor<BZip2>::Compressor(int level) : impl{leap::make_unique<BZip2>()} {
+  if (level < -1 || 9 < level)
+    throw std::invalid_argument("Compression stream level must be in the range [0, 9]");
+
+  if (level == -1)
+    level = 9;
+
+  BZ2_bzCompressInit(&impl->strm, level, 0, 0);
+}
+template<> Compressor<BZip2>::~Compressor(void) { BZ2_bzCompressEnd(&impl->strm); }
 
 template<typename T>
 DecompressionStream<T>::DecompressionStream(std::unique_ptr<IInputStream>&& is) :
@@ -123,8 +151,85 @@ bool CompressionStream<Zlib>::Transform(const void* input, size_t& ncbIn, void* 
   return rs == Z_OK;
 }
 
+// BZip2 specialization
+
+template<>
+bool DecompressionStream<BZip2>::Transform(const void* input, size_t& ncbIn, void* output, size_t& ncbOut) {
+  // Decompress into our buffer space
+  impl->strm.next_out = reinterpret_cast<char*>(output);
+  impl->strm.avail_out = static_cast<unsigned int>(ncbOut);
+  impl->strm.next_in = const_cast<char*>(reinterpret_cast<const char*>(input));
+  impl->strm.avail_in = static_cast<unsigned int>(ncbIn);
+  unsigned long avail_in, avail_out;
+  int rs;
+  do {
+    avail_in = impl->strm.avail_in;
+    avail_out = impl->strm.avail_out;
+    rs = BZ2_bzDecompress(&impl->strm);
+  } while (rs == BZ_OK && (avail_in != impl->strm.avail_in || avail_out != impl->strm.avail_out));
+  if (rs != BZ_STREAM_END && rs != BZ_OK)
+    return false;
+
+  // Store the amount we actually read/wrote
+  ncbIn -= impl->strm.avail_in;
+  ncbOut -= impl->strm.avail_out;
+
+  return true;
+}
+
+template<>
+CompressionStream<BZip2>::~CompressionStream(void) {
+  char buf[256];
+
+  // Completed!  Finish writing anything that remains to be written, and keep going
+  // as long as zlib fills up the proffered output buffer.
+  for (;;) {
+    impl->strm.avail_in = 0;
+    impl->strm.next_in = nullptr;
+    impl->strm.next_out = buf;
+    impl->strm.avail_out = static_cast<unsigned int>(sizeof(buf));
+
+    int ret = BZ2_bzCompress(&impl->strm, BZ_FINISH);
+    switch (ret) {
+    case BZ_STREAM_END:  // Return case when we are at the end
+    case BZ_FINISH_OK:   // Return case when more data exists to be written
+
+      // Handoff to lower level stream to complete the write
+      os->Write(buf, sizeof(buf) - impl->strm.avail_out);
+
+      if (ret == BZ_STREAM_END)
+        // Clean return
+        return;
+      break;
+    default:
+      // Something went wrong, and we can't throw from here, so we just have to give up
+      return;
+    }
+  }
+}
+
+template<>
+bool CompressionStream<BZip2>::Transform(const void* input, size_t& ncbIn, void* output, size_t& ncbOut, bool flush) {
+  impl->strm.avail_in = static_cast<unsigned int>(ncbIn);
+  impl->strm.next_in = const_cast<char*>(reinterpret_cast<const char*>(input));
+
+  // Compress one, update results
+  impl->strm.next_out = reinterpret_cast<char*>(output);
+  impl->strm.avail_out = static_cast<unsigned int>(ncbOut);
+  int rs;
+  do {
+    rs = BZ2_bzCompress(&impl->strm, flush ? BZ_FLUSH : BZ_RUN);
+  } while (rs == BZ_FLUSH_OK && impl->strm.avail_out > 0);
+  ncbIn -= impl->strm.avail_in;
+  ncbOut -= impl->strm.avail_out;
+  return rs == BZ_RUN_OK;
+}
+
 }
 
 // Explicit template specialization for the supported types:
+// Explicit template specialization for the supported types:
 template class leap::DecompressionStream<leap::Zlib>;
 template class leap::CompressionStream<leap::Zlib>;
+template class leap::DecompressionStream<leap::BZip2>;
+template class leap::CompressionStream<leap::BZip2>;

--- a/src/LeapSerial/CompressionStream.h
+++ b/src/LeapSerial/CompressionStream.h
@@ -11,6 +11,7 @@ namespace leap {
   /// Supported compression/decompression implementations:
   /// </summary>
   struct Zlib;
+  struct BZip2;
 
   /// <summary>
   /// Decompression interface

--- a/src/LeapSerial/CompressionStreamInternal.h
+++ b/src/LeapSerial/CompressionStreamInternal.h
@@ -1,0 +1,34 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "CompressionStream.h"
+#include <zlib/zlib.h>
+#include <bzip2/bzlib.h>
+
+namespace leap {
+
+struct Zlib {
+  Zlib(void) {
+    strm.zalloc = nullptr;
+    strm.zfree = nullptr;
+    strm.opaque = nullptr;
+    strm.avail_in = 0;
+    strm.next_in = nullptr;
+  }
+
+  // zlib state
+  z_stream_s strm;
+};
+
+struct BZip2 {
+  BZip2(void) {
+    strm.bzalloc = nullptr;
+    strm.bzfree = nullptr;
+    strm.opaque = nullptr;
+    strm.avail_in = 0;
+    strm.next_in = nullptr;
+  }
+
+  // zlib state
+  bz_stream strm;
+};
+
+}


### PR DESCRIPTION
This PR adds support for BZip2 compression when interacting with LeapSerial streams.