### PR TITLE
Disable LS_ENABLE_PROTOBUF_TESTS on Windows/ARM

### DIFF
--- a/src/LeapSerial/test/CMakeLists.txt
+++ b/src/LeapSerial/test/CMakeLists.txt
@@ -47,7 +47,11 @@ add_conditional_sources(
   FILES ArchiveFlatbufferTest.cpp TestObject.fbs
 )
 
-option(LS_ENABLE_PROTOBUF_TESTS "Enable protobuf tests" ON)
+if(MSVC OR CMAKE_CROSSCOMPILING)
+  option(LS_ENABLE_PROTOBUF_TESTS "Enable protobuf tests" OFF)
+else()
+  option(LS_ENABLE_PROTOBUF_TESTS "Enable protobuf tests" ON)
+endif()
 option(LS_PROTOBUF_REQUIRED "Require protobuf tests" OFF)
 if(LS_ENABLE_PROTOBUF_TESTS OR LS_PROTOBUF_REQUIRED)
   if(LS_PROTOBUF_REQUIRED)


### PR DESCRIPTION
The CMake config was not properly tested for #105 and breaks much of leapserial when running int he `ExternalBuilder` job, so we can disable this for now. It works fine for Mac/Linux though.