### PR TITLE
Fix Protobuf_NotFound Error in ExternalBuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
           - libprotobuf-dev
           - libprotoc-dev
   - os: osx
+    osx_image: xcode6.4
     env:
     - _CC: clang
     - _CXX: clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
           - libprotobuf-dev
           - libprotoc-dev
   - os: osx
-    osx_image: xcode6.4
     env:
     - _CC: clang
     - _CXX: clang++

--- a/src/LeapSerial/test/CMakeLists.txt
+++ b/src/LeapSerial/test/CMakeLists.txt
@@ -48,12 +48,12 @@ add_conditional_sources(
 )
 
 option(LS_ENABLE_PROTOBUF_TESTS "Enable protobuf tests" ON)
-option(LS_PROTOBUF_REQUIRED "Require protobuf tests" OFF)
+option(LS_PROTOBUF_REQUIRED "Require protobuf tests" ON)
 if(LS_ENABLE_PROTOBUF_TESTS OR LS_PROTOBUF_REQUIRED)
   if(LS_PROTOBUF_REQUIRED)
-    find_package(Protobuf 2.5.0 REQUIRED)
+    find_package(Protobuf 3.0.0.2 EXACT REQUIRED)
   else()
-    find_package(Protobuf 2.5.0 QUIET)
+    find_package(Protobuf 3.0.0.2 QUIET)
   endif()
 endif()
 

--- a/src/LeapSerial/test/CMakeLists.txt
+++ b/src/LeapSerial/test/CMakeLists.txt
@@ -48,7 +48,7 @@ add_conditional_sources(
 )
 
 option(LS_ENABLE_PROTOBUF_TESTS "Enable protobuf tests" ON)
-option(LS_PROTOBUF_REQUIRED "Require protobuf tests" ON)
+option(LS_PROTOBUF_REQUIRED "Require protobuf tests" OFF)
 if(LS_ENABLE_PROTOBUF_TESTS OR LS_PROTOBUF_REQUIRED)
   if(LS_PROTOBUF_REQUIRED)
     find_package(Protobuf 3.0.0.2 EXACT REQUIRED)


### PR DESCRIPTION
Same as the title.
- [ ] <strike>re-tag 0.4.0 for leapserial</strike>