### PR TITLE
Update minimum CMake requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
     env:
     - _CC: gcc-4.8
     - _CXX: g++-4.8
-    - CMAKE_URL=http://cmake.org/files/v3.8/cmake-3.8.2-Linux-i386.tar.gz
-    - CMAKE_DIRNAME=cmake-3.8.2-Linux-i386
+    - CMAKE_URL=http://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz
+    - CMAKE_DIRNAME=cmake-3.8.2-Linux-x86_64
     - CMAKE_EXTRA_FLAGS=-DLS_PROTOBUF_REQUIRED:BOOL=ON
     addons:
       apt:
@@ -17,7 +17,6 @@ matrix:
         packages:
           - gcc-4.8
           - g++-4.8
-          - libc6-i386
           - protobuf-compiler
           - libprotobuf-dev
           - libprotoc-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
     env:
     - _CC: gcc-4.8
     - _CXX: g++-4.8
-    - CMAKE_URL=http://cmake.org/files/v3.4/cmake-3.4.0-Linux-i386.tar.gz
-    - CMAKE_DIRNAME=cmake-3.4.0-Linux-i386
+    - CMAKE_URL=http://cmake.org/files/v3.8/cmake-3.8.2-Linux-i386.tar.gz
+    - CMAKE_DIRNAME=cmake-3.8.2-Linux-i386
     - CMAKE_EXTRA_FLAGS=-DLS_PROTOBUF_REQUIRED:BOOL=ON
     addons:
       apt:
@@ -25,8 +25,8 @@ matrix:
     env:
     - _CC: clang
     - _CXX: clang++
-    - CMAKE_URL=http://cmake.org/files/v3.4/cmake-3.4.0-Darwin-x86_64.tar.gz
-    - CMAKE_DIRNAME=cmake-3.4.0-Darwin-x86_64/CMake.app/Contents
+    - CMAKE_URL=http://cmake.org/files/v3.8/cmake-3.8.2-Darwin-x86_64.tar.gz
+    - CMAKE_DIRNAME=cmake-3.8.2-Darwin-x86_64/CMake.app/Contents
     - CMAKE_EXTRA_FLAGS=
 
 before_install:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.8)
 include(version.cmake)
 include("standard/Standard.cmake")
 


### PR DESCRIPTION
With CMake 3.9 approaching, update our minimum requirement again.

Likewise doing this for autowiring and related repositories.

- [x] Passes in Travis