### PR TITLE
Prevent accessing memory of destroyed temporary object

### DIFF
--- a/src/LeapSerial/ArchiveLeapSerial.cpp
+++ b/src/LeapSerial/ArchiveLeapSerial.cpp
@@ -441,8 +441,8 @@ void OArchiveLeapSerial::WriteInteger(int64_t value, uint8_t) {
   size_t ncb = 0;
   if (value) {
     // Write out our composed varint
-    auto buf = ToBase128(value, ncb).data();
-    WriteByteArray(buf, ncb);
+    const auto arr = ToBase128(value, ncb);
+    WriteByteArray(arr.data(), ncb);
   }
   else
     // Just write one byte of zero


### PR DESCRIPTION
The `data()` function was returning a pointer to the memory inside of the destroyed temporary object (`std::array<uint8_t, 10>`) returned by `ToBase128()`. Instead, make sure that the temporary outlives the use of the pointer.