### PR TITLE
Remove reference to std::tr1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # We have unit test projects via googletest, they're added in the places where they are defined
 enable_testing()
 
+add_definitions(-DGTEST_HAS_TR1_TUPLE=0)
+
 # Recurse through source directories
 include_directories(
   contrib


### PR DESCRIPTION
Visual Studio 2017 version 15.5 has deprecated the std::tr1 namespace. We've preferred using C++11 <tuple> on all platforms anyhow.