### PR TITLE
Update copyright year to 2018

### DIFF
--- a/scripts/copyright_check.sh
+++ b/scripts/copyright_check.sh
@@ -5,7 +5,7 @@
 #
 
 ENFORCED_FILES="LeapSerial src"
-COPYRIGHT_HEADER="// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved."
+COPYRIGHT_HEADER="// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved."
 
 # Go to root directory
 for f in $(find $ENFORCED_FILES -name *.hpp -o -name *.cpp -o -name *.h);

--- a/src/LeapSerial/AESStream.cpp
+++ b/src/LeapSerial/AESStream.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AESStream.h"
 #include <aes/rijndael-alg-fst.h>

--- a/src/LeapSerial/AESStream.h
+++ b/src/LeapSerial/AESStream.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "FilterStreamBase.h"
 #include <array>

--- a/src/LeapSerial/Allocation.cpp
+++ b/src/LeapSerial/Allocation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "Allocation.h"
 #include "field_serializer.h"

--- a/src/LeapSerial/Allocation.h
+++ b/src/LeapSerial/Allocation.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Archive.h"
 #include <vector>

--- a/src/LeapSerial/Archive.cpp
+++ b/src/LeapSerial/Archive.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "Archive.h"
 #include <iostream>

--- a/src/LeapSerial/Archive.h
+++ b/src/LeapSerial/Archive.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "IArray.h"
 #include "IDictionary.h"

--- a/src/LeapSerial/ArchiveFlatbuffer.cpp
+++ b/src/LeapSerial/ArchiveFlatbuffer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ArchiveFlatbuffer.h"
 #include "field_serializer.h"

--- a/src/LeapSerial/ArchiveFlatbuffer.h
+++ b/src/LeapSerial/ArchiveFlatbuffer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Archive.h"
 #include <vector>

--- a/src/LeapSerial/ArchiveJSON.cpp
+++ b/src/LeapSerial/ArchiveJSON.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ArchiveJSON.h"
 #include "field_serializer.h"

--- a/src/LeapSerial/ArchiveJSON.h
+++ b/src/LeapSerial/ArchiveJSON.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Archive.h"
 

--- a/src/LeapSerial/ArchiveLeapSerial.cpp
+++ b/src/LeapSerial/ArchiveLeapSerial.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ArchiveLeapSerial.h"
 #include "Allocation.h"

--- a/src/LeapSerial/ArchiveLeapSerial.h
+++ b/src/LeapSerial/ArchiveLeapSerial.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Archive.h"
 #include <queue>

--- a/src/LeapSerial/ArchiveLeapSerialV0.cpp
+++ b/src/LeapSerial/ArchiveLeapSerialV0.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ProtobufType.h"
 #include "ArchiveLeapSerialV0.h"

--- a/src/LeapSerial/ArchiveLeapSerialV0.h
+++ b/src/LeapSerial/ArchiveLeapSerialV0.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Archive.h"
 #include "ArchiveLeapSerial.h"

--- a/src/LeapSerial/ArchiveProtobuf.h
+++ b/src/LeapSerial/ArchiveProtobuf.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Archive.h"
 #include "IArchiveProtobuf.h"

--- a/src/LeapSerial/BoundedStream.cpp
+++ b/src/LeapSerial/BoundedStream.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "BoundedStream.h"
 #include <algorithm>

--- a/src/LeapSerial/BoundedStream.h
+++ b/src/LeapSerial/BoundedStream.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "IInputStream.h"
 #include "IOutputStream.h"

--- a/src/LeapSerial/BufferedInputStream.cpp
+++ b/src/LeapSerial/BufferedInputStream.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "BufferedInputStream.h"
 #include <algorithm>

--- a/src/LeapSerial/BufferedInputStream.h
+++ b/src/LeapSerial/BufferedInputStream.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "IInputStream.h"
 

--- a/src/LeapSerial/BufferedStream.cpp
+++ b/src/LeapSerial/BufferedStream.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "BufferedStream.h"
 #include <memory.h>

--- a/src/LeapSerial/BufferedStream.h
+++ b/src/LeapSerial/BufferedStream.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "BufferedInputStream.h"
 #include "IOutputStream.h"

--- a/src/LeapSerial/CompressionStream.cpp
+++ b/src/LeapSerial/CompressionStream.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "CompressionStreamInternal.h"
 #include "LeapSerial.h"

--- a/src/LeapSerial/CompressionStream.h
+++ b/src/LeapSerial/CompressionStream.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "FilterStreamBase.h"
 #include <cstdint>

--- a/src/LeapSerial/CompressionStreamInternal.h
+++ b/src/LeapSerial/CompressionStreamInternal.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "CompressionStream.h"
 #include <zlib/zlib.h>
 #include <bzip2/bzlib.h>

--- a/src/LeapSerial/Descriptor.cpp
+++ b/src/LeapSerial/Descriptor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "Descriptor.h"
 #include "serial_traits.h"

--- a/src/LeapSerial/Descriptor.h
+++ b/src/LeapSerial/Descriptor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "field_descriptor.h"
 #include "field_serializer.h"

--- a/src/LeapSerial/FilterStreamBase.cpp
+++ b/src/LeapSerial/FilterStreamBase.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "FilterStreamBase.h"
 #include <algorithm>

--- a/src/LeapSerial/FilterStreamBase.h
+++ b/src/LeapSerial/FilterStreamBase.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "IInputStream.h"
 #include "IOutputStream.h"

--- a/src/LeapSerial/ForwardingStream.h
+++ b/src/LeapSerial/ForwardingStream.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "IInputStream.h"
 #include "IOutputStream.h"

--- a/src/LeapSerial/IArchiveProtobuf.cpp
+++ b/src/LeapSerial/IArchiveProtobuf.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "IArchiveProtobuf.h"
 #include "Descriptor.h"

--- a/src/LeapSerial/IArchiveProtobuf.h
+++ b/src/LeapSerial/IArchiveProtobuf.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Archive.h"
 

--- a/src/LeapSerial/IArray.h
+++ b/src/LeapSerial/IArray.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <cstddef>
 

--- a/src/LeapSerial/IDictionary.h
+++ b/src/LeapSerial/IDictionary.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <cstddef>
 

--- a/src/LeapSerial/IInputStream.h
+++ b/src/LeapSerial/IInputStream.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <ios>
 #include <iosfwd>

--- a/src/LeapSerial/IOutputStream.h
+++ b/src/LeapSerial/IOutputStream.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "IInputStream.h"
 #include <cstdint>

--- a/src/LeapSerial/LeapSerial.h
+++ b/src/LeapSerial/LeapSerial.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Allocation.h"
 #include "Archive.h"

--- a/src/LeapSerial/LeapSerialConfig.h
+++ b/src/LeapSerial/LeapSerialConfig.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 //

--- a/src/LeapSerial/MemoryStream.cpp
+++ b/src/LeapSerial/MemoryStream.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "MemoryStream.h"
 #include <algorithm>

--- a/src/LeapSerial/MemoryStream.h
+++ b/src/LeapSerial/MemoryStream.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "IInputStream.h"
 #include "IOutputStream.h"

--- a/src/LeapSerial/OArchiveProtobuf.cpp
+++ b/src/LeapSerial/OArchiveProtobuf.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "OArchiveProtobuf.h"
 #include "Descriptor.h"

--- a/src/LeapSerial/OArchiveProtobuf.h
+++ b/src/LeapSerial/OArchiveProtobuf.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Archive.h"
 #include <memory>

--- a/src/LeapSerial/ProtobufType.h
+++ b/src/LeapSerial/ProtobufType.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Archive.h"
 

--- a/src/LeapSerial/ProtobufUtil.cpp
+++ b/src/LeapSerial/ProtobufUtil.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ProtobufUtil.hpp"
 #include "Archive.h"

--- a/src/LeapSerial/ProtobufUtil.hpp
+++ b/src/LeapSerial/ProtobufUtil.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "serialization_error.h"
 #include <memory>

--- a/src/LeapSerial/SchemaWriterProtobuf.cpp
+++ b/src/LeapSerial/SchemaWriterProtobuf.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "SchemaWriterProtobuf.h"
 #include "Descriptor.h"

--- a/src/LeapSerial/SchemaWriterProtobuf.h
+++ b/src/LeapSerial/SchemaWriterProtobuf.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "IOutputStream.h"
 #include <memory>

--- a/src/LeapSerial/StreamAdapter.cpp
+++ b/src/LeapSerial/StreamAdapter.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "StreamAdapter.h"
 #include <iostream>

--- a/src/LeapSerial/StreamAdapter.h
+++ b/src/LeapSerial/StreamAdapter.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "IInputStream.h"
 #include "IOutputStream.h"

--- a/src/LeapSerial/Utility.cpp
+++ b/src/LeapSerial/Utility.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "Utility.hpp"
 

--- a/src/LeapSerial/Utility.hpp
+++ b/src/LeapSerial/Utility.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <array>
 #include <cstdint>

--- a/src/LeapSerial/base.h
+++ b/src/LeapSerial/base.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <type_traits>
 

--- a/src/LeapSerial/descriptors.cpp
+++ b/src/LeapSerial/descriptors.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "descriptors.h"
 #include "Descriptor.h"

--- a/src/LeapSerial/descriptors.h
+++ b/src/LeapSerial/descriptors.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <iterator>
 #include <typeinfo>

--- a/src/LeapSerial/field_descriptor.h
+++ b/src/LeapSerial/field_descriptor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "base.h"
 #include "field_serializer_t.h"

--- a/src/LeapSerial/field_serializer.h
+++ b/src/LeapSerial/field_serializer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <type_traits>
 

--- a/src/LeapSerial/field_serializer_t.h
+++ b/src/LeapSerial/field_serializer_t.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Archive.h"
 #include "field_serializer.h"

--- a/src/LeapSerial/optional.h
+++ b/src/LeapSerial/optional.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <memory>
 #include <stdexcept>

--- a/src/LeapSerial/serial_traits.h
+++ b/src/LeapSerial/serial_traits.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Archive.h"
 #include "Descriptor.h"

--- a/src/LeapSerial/serialization_error.cpp
+++ b/src/LeapSerial/serialization_error.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "serialization_error.h"
 

--- a/src/LeapSerial/serialization_error.h
+++ b/src/LeapSerial/serialization_error.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <stdexcept>
 #include <string>

--- a/src/LeapSerial/stdafx.cpp
+++ b/src/LeapSerial/stdafx.cpp
@@ -1,2 +1,2 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"

--- a/src/LeapSerial/stdafx.h
+++ b/src/LeapSerial/stdafx.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 // We want zlib to provide us with a const flag for its struct declarations

--- a/src/LeapSerial/test/AESStreamTest.cpp
+++ b/src/LeapSerial/test/AESStreamTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <gtest/gtest.h>
 #include <LeapSerial/LeapSerial.h>

--- a/src/LeapSerial/test/ArchiveFlatbufferTest.cpp
+++ b/src/LeapSerial/test/ArchiveFlatbufferTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestObject.h"
 #include "TestObject_generated.h"

--- a/src/LeapSerial/test/ArchiveJSONTest.cpp
+++ b/src/LeapSerial/test/ArchiveJSONTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestObject.h"
 #include <LeapSerial/ArchiveJSON.h>

--- a/src/LeapSerial/test/ArchiveLeapSerialTest.cpp
+++ b/src/LeapSerial/test/ArchiveLeapSerialTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <LeapSerial/ArchiveLeapSerial.h>
 #include <LeapSerial/LeapSerial.h>

--- a/src/LeapSerial/test/ArchiveProtobufTest.cpp
+++ b/src/LeapSerial/test/ArchiveProtobufTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestProtobufLS.hpp"
 #include <LeapSerial/LeapSerial.h>

--- a/src/LeapSerial/test/BoundedStreamTest.cpp
+++ b/src/LeapSerial/test/BoundedStreamTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <LeapSerial/BoundedStream.h>
 #include <LeapSerial/LeapSerial.h>

--- a/src/LeapSerial/test/BufferedStreamTest.cpp
+++ b/src/LeapSerial/test/BufferedStreamTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <LeapSerial/BufferedStream.h>
 #include <gtest/gtest.h>

--- a/src/LeapSerial/test/ChronoTypesTest.cpp
+++ b/src/LeapSerial/test/ChronoTypesTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <LeapSerial/LeapSerial.h>
 #include <gtest/gtest.h>

--- a/src/LeapSerial/test/CompressionStreamTest.cpp
+++ b/src/LeapSerial/test/CompressionStreamTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <LeapSerial/LeapSerial.h>
 #include <LeapSerial/BufferedStream.h>

--- a/src/LeapSerial/test/InheritanceTest.cpp
+++ b/src/LeapSerial/test/InheritanceTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <LeapSerial/LeapSerial.h>
 #include <gtest/gtest.h>

--- a/src/LeapSerial/test/MapTest.cpp
+++ b/src/LeapSerial/test/MapTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <LeapSerial/LeapSerial.h>
 #include <gtest/gtest.h>

--- a/src/LeapSerial/test/MemoryStreamTest.cpp
+++ b/src/LeapSerial/test/MemoryStreamTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <LeapSerial/MemoryStream.h>
 #include <gtest/gtest.h>

--- a/src/LeapSerial/test/OptionalTest.cpp
+++ b/src/LeapSerial/test/OptionalTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <LeapSerial/optional.h>
 #include <gtest/gtest.h>

--- a/src/LeapSerial/test/PathologicalTest.cpp
+++ b/src/LeapSerial/test/PathologicalTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <LeapSerial/LeapSerial.h>
 #include <gtest/gtest.h>

--- a/src/LeapSerial/test/PointerTest.cpp
+++ b/src/LeapSerial/test/PointerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "LeapSerial.h"
 #include <gtest/gtest.h>

--- a/src/LeapSerial/test/PrettyPrintTest.cpp
+++ b/src/LeapSerial/test/PrettyPrintTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <LeapSerial/ArchiveJSON.h>
 #include <LeapSerial/LeapSerial.h>

--- a/src/LeapSerial/test/SchemaTest.cpp
+++ b/src/LeapSerial/test/SchemaTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestProtobufLS.hpp"
 #include <gtest/gtest.h>

--- a/src/LeapSerial/test/SerialCallbackTest.cpp
+++ b/src/LeapSerial/test/SerialCallbackTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <LeapSerial/LeapSerial.h>
 #include <gtest/gtest.h>

--- a/src/LeapSerial/test/SerialFormatTest.cpp
+++ b/src/LeapSerial/test/SerialFormatTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestObject.h"
 #include <LeapSerial/LeapSerial.h>

--- a/src/LeapSerial/test/SerializationTest.cpp
+++ b/src/LeapSerial/test/SerializationTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <LeapSerial/LeapSerial.h>
 #include <gtest/gtest.h>

--- a/src/LeapSerial/test/SerializerEnumerationTest.cpp
+++ b/src/LeapSerial/test/SerializerEnumerationTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <LeapSerial/LeapSerial.h>
 #include <gtest/gtest.h>

--- a/src/LeapSerial/test/TestObject.h
+++ b/src/LeapSerial/test/TestObject.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <LeapSerial/serial_traits.h>
 #include <cstdint>

--- a/src/LeapSerial/test/TestProtobufLS.hpp
+++ b/src/LeapSerial/test/TestProtobufLS.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <LeapSerial/LeapSerial.h>
 #include <map>

--- a/src/LeapSerial/test/stdafx.cpp
+++ b/src/LeapSerial/test/stdafx.cpp
@@ -1,2 +1,2 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"

--- a/src/LeapSerial/test/stdafx.h
+++ b/src/LeapSerial/test/stdafx.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #ifndef _STDAFX_H
 #define _STDAFX_H
 

--- a/src/LeapSerialBench/Benchmark.h
+++ b/src/LeapSerialBench/Benchmark.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <iosfwd>
 

--- a/src/LeapSerialBench/Encryption.cpp
+++ b/src/LeapSerialBench/Encryption.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "Encryption.h"
 #include "Utility.h"

--- a/src/LeapSerialBench/Encryption.h
+++ b/src/LeapSerialBench/Encryption.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Benchmark.h"
 #include <chrono>

--- a/src/LeapSerialBench/LeapSerialBench.cpp
+++ b/src/LeapSerialBench/LeapSerialBench.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "LeapSerialBench.h"
 #include "Encryption.h"

--- a/src/LeapSerialBench/LeapSerialBench.h
+++ b/src/LeapSerialBench/LeapSerialBench.h
@@ -1,2 +1,2 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once

--- a/src/LeapSerialBench/Utility.cpp
+++ b/src/LeapSerialBench/Utility.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "Utility.h"
 #include <iomanip>

--- a/src/LeapSerialBench/Utility.h
+++ b/src/LeapSerialBench/Utility.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <chrono>
 #include <iosfwd>

--- a/src/LeapSerialBench/stdafx.cpp
+++ b/src/LeapSerialBench/stdafx.cpp
@@ -1,2 +1,2 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"

--- a/src/LeapSerialBench/stdafx.h
+++ b/src/LeapSerialBench/stdafx.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 // We want zlib to provide us with a const flag for its struct declarations

--- a/src/gtest-all-guard.cpp
+++ b/src/gtest-all-guard.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #include <gtest/gtest-all.cc>
 
 using namespace std;

--- a/src/gtest-all-guard.hpp
+++ b/src/gtest-all-guard.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 /// <summary>


### PR DESCRIPTION
Looks like the `scripts/copyright_check.sh` script in leapserial got neglected for a couple years!